### PR TITLE
Add argument checks for inverse of ScaledShiftedLogistic and some tests

### DIFF
--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -110,11 +110,15 @@ transform_and_logjac(t::ScaledShiftedLogistic, x) =
     transform(t, x), log(t.scale) + logistic_logjac(x)
 
 function inverse(t::ScaledShiftedLogistic, y)
+    @argcheck y > t.shift           DomainError
+    @argcheck y < t.scale + t.shift DomainError
     logit((y - t.shift)/t.scale)
 end
 
 # NOTE: inverse_and_logjac interface experimental and sporadically implemented for now
 function inverse_and_logjac(t::ScaledShiftedLogistic, y)
+    @argcheck y > t.shift           DomainError
+    @argcheck y < t.scale + t.shift DomainError
     z = (y - t.shift) / t.scale
     logit(z), logit_logjac(z) - log(t.scale)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ import Flux, ForwardDiff, ReverseDiff
 using LogDensityProblems: Value, ValueGradient
 using TransformVariables:
     AbstractTransform, ScalarTransform, VectorTransform, ArrayTransform,
-    unit_triangular_dimension, logistic, logistic_logjac, logit
+    unit_triangular_dimension, logistic, logistic_logjac, logit, inverse_and_logjac
 
 include("test_utilities.jl")
 
@@ -49,6 +49,18 @@ end
     @test_throws ArgumentError as(Real, "a fish", 9)
     @test as(Real, 1, 4.0) == as(Real, 1.0, 4.0)
     @test_throws ArgumentError as(Real, 3.0, -4.0)
+
+    t = as(Real, 1.0, ∞)
+    @test_throws DomainError inverse(t, 0.5)
+
+    t = as(Real, -∞, 10.0)
+    @test_throws DomainError inverse(t, 11.0)
+
+    t = as(Real, 1.0, 10.0)
+    @test_throws DomainError inverse(t, 0.5)
+    @test_throws DomainError inverse(t, 11.0)
+    @test_throws DomainError inverse_and_logjac(t, 0.5)
+    @test_throws DomainError inverse_and_logjac(t, 11.0)
 end
 
 @testset "to unit vector" begin


### PR DESCRIPTION
Otherwise it throws a `DomainError` when trying to compute the `log` of a negative number. I think this error is a bit more informative and it matches the behavior of `ShiftedExp`.