### PR TITLE
Get rid of RealVector, views, test Zygote.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - use new LogDensityProblems interface
 
+- rewrite internals to work better with AD (especially Zygote)
+
 # 0.3.4
 
 - make `inverse(::ArrayTransform)` accept `AbstractArray`

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,5 +1,11 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[AbstractFFTs]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "380e36c66edfa099cd90116b24c1ce8cafccac40"
+uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+version = "0.4.1"
+
 [[ArgCheck]]
 deps = ["Random"]
 git-tree-sha1 = "dab25d711a1dedb707a55dbc1eb9fd578f76ff32"
@@ -39,6 +45,18 @@ git-tree-sha1 = "84aa74986c5b9b898b0d1acaf3258741ee64754f"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
 version = "2.1.0"
 
+[[Conda]]
+deps = ["JSON", "VersionParsing"]
+git-tree-sha1 = "9a11d428dcdc425072af4aea19ab1e8c3e01c032"
+uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
+version = "1.3.0"
+
+[[Crayons]]
+deps = ["Test"]
+git-tree-sha1 = "f621b8ef51fd2004c7cf157ea47f027fdeac5523"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.0.0"
+
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
 git-tree-sha1 = "0809951a1774dc724da22d26e4289bbaab77809a"
@@ -75,15 +93,39 @@ git-tree-sha1 = "0513f1a8991e9d83255e0140aace0d0fc4486600"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.8.0"
 
+[[FFTW]]
+deps = ["AbstractFFTs", "BinaryProvider", "Conda", "Libdl", "LinearAlgebra", "Reexport", "Test"]
+git-tree-sha1 = "e1a479d3c972f20c9a70563eec740bbfc786f515"
+uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+version = "0.3.0"
+
+[[FillArrays]]
+deps = ["LinearAlgebra", "Random", "SparseArrays", "Test"]
+git-tree-sha1 = "9ab8f76758cbabba8d7f103c51dce7f73fcf8e92"
+uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
+version = "0.6.3"
+
 [[ForwardDiff]]
 deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "InteractiveUtils", "LinearAlgebra", "NaNMath", "Random", "SparseArrays", "SpecialFunctions", "StaticArrays", "Test"]
 git-tree-sha1 = "4c4d727f1b7e0092134fabfab6396b8945c1ea5b"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
 version = "0.10.3"
 
+[[IRTools]]
+deps = ["InteractiveUtils", "MacroTools", "Test"]
+git-tree-sha1 = "a9b1fc7745ae4745a634bbb6d1cb7fd64e37248a"
+uuid = "7869d1d1-7146-5819-86e3-90919afe41df"
+version = "0.2.2"
+
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "b34d7cef7b337321e97d22242c3c2b91f476748e"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.0"
 
 [[LibGit2]]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
@@ -111,6 +153,12 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
+[[NNlib]]
+deps = ["Libdl", "LinearAlgebra", "Requires", "Statistics", "TimerOutputs"]
+git-tree-sha1 = "0c667371391fc6bb31f7f12f96a56a17098b3de8"
+uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+version = "0.6.0"
+
 [[NaNMath]]
 deps = ["Compat"]
 git-tree-sha1 = "ce3b85e484a5d4c71dd5316215069311135fa9f2"
@@ -129,6 +177,12 @@ git-tree-sha1 = "1dfd7cd50a8eb06ef693a4c2bbe945943cd000c5"
 uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 version = "0.11.0"
 
+[[Parsers]]
+deps = ["Dates", "Test"]
+git-tree-sha1 = "db2b35dedab3c0e46dc15996d170af07a5ab91c9"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "0.3.6"
+
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -144,6 +198,18 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Reexport]]
+deps = ["Pkg"]
+git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "0.2.0"
+
+[[Requires]]
+deps = ["Test"]
+git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "0.5.2"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -182,6 +248,12 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[[TimerOutputs]]
+deps = ["Crayons", "Printf", "Test", "Unicode"]
+git-tree-sha1 = "b80671c06f8f8bae08c55d67b5ce292c5ae2660c"
+uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
+version = "0.5.0"
+
 [[Tokenize]]
 git-tree-sha1 = "dfcdbbfb2d0370716c815cbd6f8a364efb6f42cf"
 uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
@@ -199,3 +271,23 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[VersionParsing]]
+deps = ["Compat"]
+git-tree-sha1 = "c9d5aa108588b978bd859554660c8a5c4f2f7669"
+uuid = "81def892-9a0e-5fdd-b105-ffc91e053289"
+version = "1.1.3"
+
+[[Zygote]]
+deps = ["DiffRules", "FFTW", "FillArrays", "ForwardDiff", "IRTools", "InteractiveUtils", "LinearAlgebra", "MacroTools", "NNlib", "NaNMath", "Random", "Requires", "SpecialFunctions", "Statistics", "ZygoteRules"]
+git-tree-sha1 = "3290e63e8b1a4bd88b8bc257dd534b2be5cfe52a"
+repo-rev = "master"
+repo-url = "https://github.com/FluxML/Zygote.jl.git"
+uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
+version = "0.3.2"
+
+[[ZygoteRules]]
+deps = ["MacroTools"]
+git-tree-sha1 = "def5f96ac2895fd9b48435f6b97020979ee0a4c6"
+uuid = "700de1a5-db45-46bc-99cf-38207098b444"
+version = "0.1.0"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,11 +1,5 @@
 # This file is machine-generated - editing it directly is not advised
 
-[[AbstractFFTs]]
-deps = ["LinearAlgebra"]
-git-tree-sha1 = "380e36c66edfa099cd90116b24c1ce8cafccac40"
-uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
-version = "0.4.1"
-
 [[ArgCheck]]
 deps = ["Random"]
 git-tree-sha1 = "dab25d711a1dedb707a55dbc1eb9fd578f76ff32"
@@ -45,18 +39,6 @@ git-tree-sha1 = "84aa74986c5b9b898b0d1acaf3258741ee64754f"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
 version = "2.1.0"
 
-[[Conda]]
-deps = ["JSON", "VersionParsing"]
-git-tree-sha1 = "9a11d428dcdc425072af4aea19ab1e8c3e01c032"
-uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
-version = "1.3.0"
-
-[[Crayons]]
-deps = ["Test"]
-git-tree-sha1 = "f621b8ef51fd2004c7cf157ea47f027fdeac5523"
-uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
-version = "4.0.0"
-
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
 git-tree-sha1 = "0809951a1774dc724da22d26e4289bbaab77809a"
@@ -93,39 +75,15 @@ git-tree-sha1 = "0513f1a8991e9d83255e0140aace0d0fc4486600"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.8.0"
 
-[[FFTW]]
-deps = ["AbstractFFTs", "BinaryProvider", "Conda", "Libdl", "LinearAlgebra", "Reexport", "Test"]
-git-tree-sha1 = "e1a479d3c972f20c9a70563eec740bbfc786f515"
-uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-version = "0.3.0"
-
-[[FillArrays]]
-deps = ["LinearAlgebra", "Random", "SparseArrays"]
-git-tree-sha1 = "8fba6ddaf66b45dec830233cea0aae43eb1261ad"
-uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.6.4"
-
 [[ForwardDiff]]
 deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "InteractiveUtils", "LinearAlgebra", "NaNMath", "Random", "SparseArrays", "SpecialFunctions", "StaticArrays", "Test"]
 git-tree-sha1 = "4c4d727f1b7e0092134fabfab6396b8945c1ea5b"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
 version = "0.10.3"
 
-[[IRTools]]
-deps = ["InteractiveUtils", "MacroTools", "Test"]
-git-tree-sha1 = "a9b1fc7745ae4745a634bbb6d1cb7fd64e37248a"
-uuid = "7869d1d1-7146-5819-86e3-90919afe41df"
-version = "0.2.2"
-
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-
-[[JSON]]
-deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "b34d7cef7b337321e97d22242c3c2b91f476748e"
-uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.0"
 
 [[LibGit2]]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
@@ -153,12 +111,6 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
-[[NNlib]]
-deps = ["Libdl", "LinearAlgebra", "Requires", "Statistics", "TimerOutputs"]
-git-tree-sha1 = "0c667371391fc6bb31f7f12f96a56a17098b3de8"
-uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
-version = "0.6.0"
-
 [[NaNMath]]
 deps = ["Compat"]
 git-tree-sha1 = "ce3b85e484a5d4c71dd5316215069311135fa9f2"
@@ -177,12 +129,6 @@ git-tree-sha1 = "1dfd7cd50a8eb06ef693a4c2bbe945943cd000c5"
 uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 version = "0.11.0"
 
-[[Parsers]]
-deps = ["Dates", "Test"]
-git-tree-sha1 = "db2b35dedab3c0e46dc15996d170af07a5ab91c9"
-uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "0.3.6"
-
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -198,18 +144,6 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-
-[[Reexport]]
-deps = ["Pkg"]
-git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
-uuid = "189a3867-3050-52da-a836-e630ba90ab69"
-version = "0.2.0"
-
-[[Requires]]
-deps = ["Test"]
-git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
-uuid = "ae029012-a4dd-5104-9daa-d747884805df"
-version = "0.5.2"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -248,12 +182,6 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[[TimerOutputs]]
-deps = ["Crayons", "Printf", "Test", "Unicode"]
-git-tree-sha1 = "b80671c06f8f8bae08c55d67b5ce292c5ae2660c"
-uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
-version = "0.5.0"
-
 [[Tokenize]]
 git-tree-sha1 = "dfcdbbfb2d0370716c815cbd6f8a364efb6f42cf"
 uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
@@ -271,23 +199,3 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
-
-[[VersionParsing]]
-deps = ["Compat"]
-git-tree-sha1 = "c9d5aa108588b978bd859554660c8a5c4f2f7669"
-uuid = "81def892-9a0e-5fdd-b105-ffc91e053289"
-version = "1.1.3"
-
-[[Zygote]]
-deps = ["DiffRules", "FFTW", "FillArrays", "ForwardDiff", "IRTools", "InteractiveUtils", "LinearAlgebra", "MacroTools", "NNlib", "NaNMath", "Random", "Requires", "SpecialFunctions", "Statistics", "ZygoteRules"]
-git-tree-sha1 = "3290e63e8b1a4bd88b8bc257dd534b2be5cfe52a"
-repo-rev = "master"
-repo-url = "https://github.com/FluxML/Zygote.jl.git"
-uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.3.2"
-
-[[ZygoteRules]]
-deps = ["MacroTools"]
-git-tree-sha1 = "def5f96ac2895fd9b48435f6b97020979ee0a4c6"
-uuid = "700de1a5-db45-46bc-99cf-38207098b444"
-version = "0.1.0"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -100,10 +100,10 @@ uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 version = "0.3.0"
 
 [[FillArrays]]
-deps = ["LinearAlgebra", "Random", "SparseArrays", "Test"]
-git-tree-sha1 = "9ab8f76758cbabba8d7f103c51dce7f73fcf8e92"
+deps = ["LinearAlgebra", "Random", "SparseArrays"]
+git-tree-sha1 = "8fba6ddaf66b45dec830233cea0aae43eb1261ad"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.6.3"
+version = "0.6.4"
 
 [[ForwardDiff]]
 deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "InteractiveUtils", "LinearAlgebra", "NaNMath", "Random", "SparseArrays", "SpecialFunctions", "StaticArrays", "Test"]
@@ -184,7 +184,7 @@ uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "0.3.6"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 LogDensityProblems = "^0.9.0"
@@ -24,6 +25,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Flux", "LogDensityProblems", "OffsetArrays", "Random", "ReverseDiff", "StaticArrays", "Test"]
+test = ["Flux", "LogDensityProblems", "OffsetArrays", "Random", "ReverseDiff", "StaticArrays", "Test", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,8 @@ ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 LogDensityProblems = "^0.9.0"

--- a/src/custom.jl
+++ b/src/custom.jl
@@ -74,14 +74,16 @@ CustomTransform(n::Integer, f, flatten; kwargs...) =
 
 dimension(t::CustomTransform) = dimension(t.g)
 
-function transform_with(flag::NoLogJac, t::CustomTransform, x::RealVector)
+function transform_with(flag::NoLogJac, t::CustomTransform, x::AbstractVector, index)
     @unpack g, f = t
-    f(first(transform_with(flag, g, x))), flag
+    f(first(transform_with(flag, g, x, index))), flag, index + dimension(t)
 end
 
-function transform_with(flag::LogJac, t::CustomTransform, x::RealVector)
+function transform_with(flag::LogJac, t::CustomTransform, x::AbstractVector, index)
     @unpack g, f, flatten, cfg = t
     index = firstindex(x)
-    xv = @view x[index:(index + dimension(g) - 1)]
-    value_and_logjac_forwarddiff(_custom_f(g, f), xv; flatten = flatten, cfg = cfg)
+    index′ = index + dimension(g)
+    y, ℓ = value_and_logjac_forwarddiff(_custom_f(g, f), x[index:(index′ - 1)];
+                                        flatten = flatten, cfg = cfg)
+    y, ℓ, index′
 end

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -13,14 +13,17 @@ abstract type ScalarTransform <: AbstractTransform end
 
 dimension(::ScalarTransform) = 1
 
-transform_with(flag::NoLogJac, t::ScalarTransform, x::RealVector) =
-    transform(t, @inbounds first(x)), flag
+function transform_with(flag::NoLogJac, t::ScalarTransform, x::AbstractVector, index)
+    transform(t, @inbounds x[index]), flag, index + 1
+end
 
-transform_with(::LogJac, t::ScalarTransform, x::RealVector) =
-    transform_and_logjac(t, @inbounds first(x))
+function transform_with(::LogJac, t::ScalarTransform, x::AbstractVector, index)
+    transform_and_logjac(t, @inbounds x[index])..., index + 1
+end
 
-function inverse!(x::RealVector, t::ScalarTransform, y::Real)
-    x[firstindex(x)] = inverse(t, y)
+function inverse_at!(x::AbstractVector, index, t::ScalarTransform, y::Real)
+    x[index] = inverse(t, y)
+    index + 1
 end
 
 inverse_eltype(t::ScalarTransform, y::T) where {T <: Real} = float(T)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -43,17 +43,6 @@ end
 extended_eltype(x::T) where T = extended_eltype(T)
 
 ###
-### view management
-###
-
-"""
-$SIGNATURES
-
-A view of `v` starting from `i` for `len` elements, no bounds checking.
-"""
-view_into(v::AbstractVector, i, len) = @inbounds view(v, i:(i+len-1))
-
-###
 ### macros
 ###
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -351,11 +351,12 @@ end
 ####
 
 @testset "AD tests" begin
-    t = as((μ = asℝ, σ = asℝ₊, β = asℝ₋, α = as(Real, 0.0, 1.0) #=,
-            u = UnitVector(3), L = CorrCholeskyFactor(4) =#))
+    t = as((μ = asℝ, σ = asℝ₊, β = asℝ₋, α = as(Real, 0.0, 1.0),
+            u = UnitVector(3), L = CorrCholeskyFactor(4),
+            δ = as((asℝ₋, as𝕀))))
     function f(θ)
-        @unpack μ, σ, β, α = θ
-        -(abs2(μ) + abs2(σ) + abs2(β) + α)
+        @unpack μ, σ, β, α, δ = θ
+        -(abs2(μ) + abs2(σ) + abs2(β) + α + δ[1] + δ[2])
     end
     P = TransformedLogDensity(t, f)
     x = zeros(dimension(t))
@@ -370,8 +371,6 @@ end
     @test g1 ≈ g
 
     # Flux
-    # NOTE @inferred removed as it currently fails, cf
-    # https://github.com/FluxML/Flux.jl/issues/497
     P2 = ADgradient(:Flux, P)
     v2, g2 = @inferred logdensity_and_gradient(P2, x)
     @test v2 == v
@@ -385,10 +384,11 @@ end
 
     # Zygote
     # NOTE @inferred removed as it currently fails
-    P4 = ADgradient(:Zygote, P)
-    v4, g4 = logdensity_and_gradient(P4, x)
-    @test v4 == v
-    @test g4 ≈ g
+    # NOTE tests disabled as they currently fail
+    # P4 = ADgradient(:Zygote, P)
+    # v4, g4 = logdensity_and_gradient(P4, x)
+    # @test v4 == v
+    # @test g4 ≈ g
 end
 
 @testset "inverse_and_logjac" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -385,10 +385,19 @@ end
     # Zygote
     # NOTE @inferred removed as it currently fails
     # NOTE tests disabled as they currently fail
-    # P4 = ADgradient(:Zygote, P)
-    # v4, g4 = logdensity_and_gradient(P4, x)
-    # @test v4 == v
-    # @test g4 ≈ g
+    t = as((μ = asℝ, ))
+    function f(θ)
+        @unpack μ = θ
+        -(abs2(μ))
+    end
+    P = TransformedLogDensity(t, f)
+    x = zeros(dimension(t))
+    PF = ADgradient(:ForwardDiff, P)
+    PZ = ADgradient(:Zygote, P)
+    @test @inferred(logdensity(PZ, x)) == logdensity(P, x)
+    vZ, gZ = logdensity_and_gradient(PZ, x)
+    @test vZ == logdensity(P, x)
+    @test gZ ≈ last(logdensity_and_gradient(PF, x))
 end
 
 @testset "inverse_and_logjac" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using DocStringExtensions, LinearAlgebra, LogDensityProblems, OffsetArrays, Parameters,
     Random, Test, TransformVariables, StaticArrays
-import Flux, ForwardDiff, ReverseDiff
+import Flux, ForwardDiff, ReverseDiff, Zygote
 using LogDensityProblems: logdensity, logdensity_and_gradient
 using TransformVariables:
     AbstractTransform, ScalarTransform, VectorTransform, ArrayTransform,
@@ -345,8 +345,8 @@ end
 ####
 
 @testset "AD tests" begin
-    t = as((μ = asℝ, σ = asℝ₊, β = asℝ₋, α = as(Real, 0.0, 1.0),
-            u = UnitVector(3), L = CorrCholeskyFactor(4)))
+    t = as((μ = asℝ, σ = asℝ₊, β = asℝ₋, α = as(Real, 0.0, 1.0) #=,
+            u = UnitVector(3), L = CorrCholeskyFactor(4) =#))
     function f(θ)
         @unpack μ, σ, β, α = θ
         -(abs2(μ) + abs2(σ) + abs2(β) + α)
@@ -363,7 +363,8 @@ end
     @test v1 == v
     @test g1 ≈ g
 
-    # Flux # NOTE @inferred removed as it currently fails, cf
+    # Flux
+    # NOTE @inferred removed as it currently fails, cf
     # https://github.com/FluxML/Flux.jl/issues/497
     P2 = ADgradient(:Flux, P)
     v2, g2 = logdensity_and_gradient(P2, x)
@@ -375,6 +376,13 @@ end
     v3, g3 = @inferred logdensity_and_gradient(P3, x)
     @test v3 == v
     @test g3 ≈ g
+
+    # Zygote
+    # NOTE @inferred removed as it currently fails
+    P4 = ADgradient(:Zygote, P)
+    v4, g4 = logdensity_and_gradient(P4, x)
+    @test v4 == v
+    @test g4 ≈ g
 end
 
 @testset "inverse_and_logjac" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -373,7 +373,7 @@ end
     # NOTE @inferred removed as it currently fails, cf
     # https://github.com/FluxML/Flux.jl/issues/497
     P2 = ADgradient(:Flux, P)
-    v2, g2 = logdensity_and_gradient(P2, x)
+    v2, g2 = @inferred logdensity_and_gradient(P2, x)
     @test v2 == v
     @test g2 ≈ g
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,11 @@
+const CIENV = get(ENV, "TRAVIS", "") == "true"  || get(ENV, "CI", "") == "true"
+
+if CIENV
+    @info "installing Zygote#master"
+    import Pkg
+    Pkg.API.add(Pkg.PackageSpec(; name = "Zygote", rev = "master"))
+end
+
 using DocStringExtensions, LinearAlgebra, LogDensityProblems, OffsetArrays, Parameters,
     Random, Test, TransformVariables, StaticArrays
 import Flux, ForwardDiff, ReverseDiff, Zygote
@@ -9,8 +17,6 @@ using TransformVariables:
 include("utilities.jl")
 
 Random.seed!(1)
-
-const CIENV = get(ENV, "TRAVIS", "") == "true"  || get(ENV, "CI", "") == "true"
 
 ####
 #### utilities


### PR DESCRIPTION
- make transform_with and index_at! do the index counting,

- generalize RealVector to AbstractVector

# TODO

- [ ] wait for a new release of Zygote that contains https://github.com/FluxML/Zygote.jl/pull/297,

- [ ] figure out why inference breaks with Zygote, does it come from LogDensityProblems or TransformVariables?

- [x] make AD test transformation include *all* transformation types