### PR TITLE
Pretty-print `ScalarTransform`s

### DIFF
--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -209,3 +209,23 @@ Transform to the real line (identity).
 const asℝ = as(Real, -∞, ∞)
 
 const as_real = asℝ
+
+Base.show(io::IO, t::ShiftedExp) =
+    if t === asℝ₊
+        print(io, "asℝ₊")
+    elseif t === asℝ₋
+        print(io, "asℝ₋")
+    elseif t isa ShiftedExp{true}
+        print(io, "as(Real, ", t.shift, ", ∞)")
+    else
+        print(io, "as(Real, -∞, ", t.shift, ")")
+    end
+
+Base.show(io::IO, t::ScaledShiftedLogistic) =
+    if t === as𝕀
+        print(io, "as𝕀")
+    else
+        print(io, "as(Real, ", t.shift, ", ", t.shift + t.scale, ")")
+    end
+
+Base.show(io::IO, t::Identity) = print(io, "asℝ")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -462,3 +462,17 @@ end
     x = [zeros(d), zeros(d)]
     @test t.(x) == map(t, x)
 end
+
+####
+#### show
+####
+
+@testset "scalar show" begin
+    @test string(asℝ) == "asℝ"
+    @test string(asℝ₊) == "asℝ₊"
+    @test string(asℝ₋) == "asℝ₋"
+    @test string(as𝕀) == "as𝕀"
+    @test string(as(Real, 0.0, 2.0)) == "as(Real, 0.0, 2.0)"
+    @test string(as(Real, 1.0, ∞)) == "as(Real, 1.0, ∞)"
+    @test string(as(Real, -∞, 1.0)) == "as(Real, -∞, 1.0)"
+end


### PR DESCRIPTION
Hi, thanks for a useful package. What do you think about pretty-printing scalar transforms?

```julia
julia> asℝ₊
asℝ₊

julia> as𝕀
as𝕀

julia> as(Real, 0.0, 1.0)
as𝕀

julia> as(Real, 0.0, 2.0)
as(Real, 0.0, 2.0)
```
