### PR TITLE
Fix some aggregator indexing issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Unreleased
 
+- fix some tuple index bugs (cf [#58])
+
 # 0.3.6
 
-- Pretty print scalar transforms (#54, thanks @tkf)
+- Pretty print scalar transforms ([#54], thanks @tkf)
 
 # 0.3.5
 

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -125,9 +125,9 @@ version = "1.1.0"
 
 [[Parameters]]
 deps = ["OrderedCollections"]
-git-tree-sha1 = "1dfd7cd50a8eb06ef693a4c2bbe945943cd000c5"
+git-tree-sha1 = "b62b2558efb1eef1fa44e4be5ff58a515c287e38"
 uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
-version = "0.11.0"
+version = "0.12.0"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
@@ -163,10 +163,10 @@ deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SpecialFunctions]]
-deps = ["BinDeps", "BinaryProvider", "Libdl", "Test"]
-git-tree-sha1 = "0b45dc2e45ed77f445617b99ff2adf0f5b0f23ea"
+deps = ["BinDeps", "BinaryProvider", "Libdl"]
+git-tree-sha1 = "3bdd374b6fd78faf0119b8c5d538788dbf910c6e"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "0.7.2"
+version = "0.8.0"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]

--- a/src/aggregation.jl
+++ b/src/aggregation.jl
@@ -57,11 +57,13 @@ end
 function transform_with(flag::LogJacFlag, t::ArrayTransform, x, index::T) where {T}
     @unpack transformation, dims = t
     # NOTE not using index increments as that somehow breaks type inference
-    d = dimension(transformation)
-    𝐼 = reshape(range(index; length = prod(dims), step = d), dims)
+    d = dimension(transformation) # length of an element transformation
+    len = prod(dims)              # number of elements
+    𝐼 = reshape(range(index; length = len, step = d), dims)
     yℓ = map(index -> ((y, ℓ, _) = transform_with(flag, transformation, x, index); (y, ℓ)), 𝐼)
     ℓz = logjac_zero(flag, extended_eltype(x))
-    first.(yℓ), isempty(yℓ) ? ℓz : ℓz + sum(last, yℓ), index
+    index′ = index + d * len
+    first.(yℓ), isempty(yℓ) ? ℓz : ℓz + sum(last, yℓ), index′
 end
 
 function transform_with(flag::LogJacFlag, t::ArrayTransform{Identity}, x, index)
@@ -208,7 +210,6 @@ end
 function inverse_at!(x::AbstractVector, index, tt::TransformTuple{<:Tuple}, y::Tuple)
     @unpack transformations = tt
     @argcheck length(transformations) == length(y)
-    @argcheck length(x) == dimension(tt)
     _inverse!_tuple(x, index, tt.transformations, y)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -252,6 +252,19 @@ end
     @test_skip inverse(za, []) == []
 end
 
+@testset "nested combinations" begin
+    # for https://github.com/tpapp/TransformVariables.jl/issues/57
+    for _ in 1:10
+        N = rand(3:7)
+        tt = as((a = as(Tuple(as(Vector, asℝ₊, 2) for _ in 1:N)),
+                 b = as(Tuple(UnitVector(n) for n in 1:N))))
+        x = randn(dimension(tt))
+        y = tt(x)
+        x′ = inverse(tt, y)
+        @test x ≈ x′
+    end
+end
+
 ####
 #### log density correctness checks
 ####


### PR DESCRIPTION
- remove bogus argcheck (we are only using part of the target)

- fix non-incremented vector aggregator

- add tests

Fixes #57.

Incidental: upgrade packages in manifest.