### PR TITLE
Fix UnitVector implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
+Flux = "0.9"
 LogDensityProblems = "^0.9.0"
 julia = "^1"
 

--- a/src/aggregation.jl
+++ b/src/aggregation.jl
@@ -131,7 +131,7 @@ Return a transformation that transforms consecutive groups of real numbers to a
 julia> t = as((asℝ₊, UnitVector(3)));
 
 julia> dimension(t)
-3
+4
 
 julia> transform(t, zeros(dimension(t)))
 (1.0, [0.0, 0.0, 1.0])
@@ -139,7 +139,7 @@ julia> transform(t, zeros(dimension(t)))
 julia> t2 = as((σ = asℝ₊, u = UnitVector(3)));
 
 julia> dimension(t2)
-3
+4
 
 julia> transform(t2, zeros(dimension(t2)))
 (σ = 1.0, u = [0.0, 0.0, 1.0])

--- a/src/aggregation.jl
+++ b/src/aggregation.jl
@@ -134,7 +134,7 @@ julia> dimension(t)
 4
 
 julia> transform(t, zeros(dimension(t)))
-(1.0, [0.0, 0.0, 1.0])
+(1.0, [1.0, 0.0, 0.0])
 
 julia> t2 = as((σ = asℝ₊, u = UnitVector(3)));
 
@@ -142,7 +142,7 @@ julia> dimension(t2)
 4
 
 julia> transform(t2, zeros(dimension(t2)))
-(σ = 1.0, u = [0.0, 0.0, 1.0])
+(σ = 1.0, u = [1.0, 0.0, 0.0])
 ```
 """
 as(transformations::NTransforms) = TransformTuple(transformations)

--- a/src/special_arrays.jl
+++ b/src/special_arrays.jl
@@ -54,7 +54,7 @@ function transform_with(flag::LogJacFlag, t::UnitVector, x::AbstractVector, inde
     index′ = index + n
     vx = view(x, index:(index′ - 1))
     nx² = sum(abs2, vx)
-    y = nx² > 0 ? vx ./ √nx² : [zeros(T, n - 1); one(T)]
+    y = nx² > 0 ? vx ./ √nx² : [one(T); zeros(T, n - 1)]
     ℓ = logjac_zero(flag, T)
     if !(flag isa NoLogJac)
         ℓ -= nx² / 2

--- a/src/special_arrays.jl
+++ b/src/special_arrays.jl
@@ -54,7 +54,7 @@ function transform_with(flag::LogJacFlag, t::UnitVector, x::AbstractVector, inde
     index′ = index + n
     vx = view(x, index:(index′ - 1))
     nx² = sum(abs2, vx)
-    y = vx ./ √nx²
+    y = nx² > 0 ? vx ./ √nx² : [zeros(T, n - 1); one(T)]
     ℓ = logjac_zero(flag, T)
     if !(flag isa NoLogJac)
         ℓ -= nx² / 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -504,7 +504,7 @@ end
 
     t = UnitVector(3)
     d = dimension(t)
-    x = [randn(d), randn(d)]
+    x = [zeros(d), zeros(d)]
     @test t.(x) == map(t, x)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,7 +85,7 @@ end
 @testset "to unit vector" begin
     @testset "dimension checks" begin
         U = UnitVector(3)
-        x = zeros(3)               # incorrect
+        x = zeros(2)               # incorrect
         @test_throws ArgumentError U(x)
         @test_throws ArgumentError transform(U, x)
         @test_throws ArgumentError transform_and_logjac(U, x)
@@ -94,10 +94,10 @@ end
     @testset "consistency checks" begin
         for K in 1:10
             t = UnitVector(K)
-            @test dimension(t) == K - 1
+            @test dimension(t) == K
             if K > 1
-                test_transformation(t, y -> sum(abs2, y) ≈ 1,
-                                    vec_y = y -> y[1:(end-1)])
+                test_transformation(t, y -> sum(abs2, y) ≈ 1;
+                                    test_inverse = false, test_logjac = false)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -503,7 +503,7 @@ end
 
     t = UnitVector(3)
     d = dimension(t)
-    x = [zeros(d), zeros(d)]
+    x = [randn(d), randn(d)]
     @test t.(x) == map(t, x)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -394,11 +394,11 @@ end
             u = UnitVector(3), L = CorrCholeskyFactor(4),
             δ = as((asℝ₋, as𝕀))))
     function f(θ)
-        @unpack μ, σ, β, α, δ = θ
-        -(abs2(μ) + abs2(σ) + abs2(β) + α + δ[1] + δ[2])
+        @unpack μ, σ, β, α, u, δ = θ
+        -(abs2(μ) + abs2(σ) + abs2(β) + α + sum(u) + δ[1] + δ[2])
     end
     P = TransformedLogDensity(t, f)
-    x = zeros(dimension(t))
+    x = randn(dimension(t)) .* 1e-5
     v = logdensity(P, x)
     g = ForwardDiff.gradient(x -> logdensity(P, x), x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,6 +105,7 @@ end
                 ι = inverse(t)
                 @test y ≈ ι(y)
                 @test transform_and_logjac(t, x)[2] ≈ -sum(abs2, x) ./ 2
+                @test transform(t, zeros(K)) ≈ [zeros(K-1); 1]
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -249,7 +249,8 @@ end
     x = randn(dimension(tn))
     y = @inferred transform(tn, x)
     @test y isa NamedTuple{(:a,:b,:c)}
-    @test inverse(tn, y) ≈ x
+    x2 = inverse(tn, y)
+    @test inverse(tn, transform(tn, x2)) ≈ x2
     index = 0
     ljacc = 0.0
     for (i, t) in enumerate((t1, t2, t3))
@@ -291,7 +292,7 @@ end
         x = randn(dimension(tt))
         y = tt(x)
         x′ = inverse(tt, y)
-        @test x ≈ x′
+        @test inverse(tt, transform(tt, x′)) ≈ x′
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,6 +98,13 @@ end
             if K > 1
                 test_transformation(t, y -> sum(abs2, y) ≈ 1;
                                     test_inverse = false, test_logjac = false)
+                x = randn(K)
+                y = transform(t, x)
+                x2 = @inferred inverse(t, y)
+                @test x2 ≈ y
+                ι = inverse(t)
+                @test y ≈ ι(y)
+                @test transform_and_logjac(t, x)[2] ≈ -sum(abs2, x) ./ 2
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -398,7 +398,7 @@ end
         -(abs2(μ) + abs2(σ) + abs2(β) + α + δ[1] + δ[2])
     end
     P = TransformedLogDensity(t, f)
-    x = randn(dimension(t))
+    x = zeros(dimension(t))
     v = logdensity(P, x)
     g = ForwardDiff.gradient(x -> logdensity(P, x), x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,7 +105,7 @@ end
                 ι = inverse(t)
                 @test y ≈ ι(y)
                 @test transform_and_logjac(t, x)[2] ≈ -sum(abs2, x) ./ 2
-                @test transform(t, zeros(K)) ≈ [zeros(K-1); 1]
+                @test transform(t, zeros(K)) ≈ [1; zeros(K-1)]
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -397,7 +397,7 @@ end
         -(abs2(μ) + abs2(σ) + abs2(β) + α + δ[1] + δ[2])
     end
     P = TransformedLogDensity(t, f)
-    x = zeros(dimension(t))
+    x = randn(dimension(t))
     v = logdensity(P, x)
     g = ForwardDiff.gradient(x -> logdensity(P, x), x)
 

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -22,7 +22,8 @@ automatic differentiation.
 `test_inverse` determines whether the inverse is tested.
 """
 function test_transformation(t::AbstractTransform, is_valid_y;
-                             vec_y = identity, N = 1000, test_inverse = true)
+                             vec_y = identity, N = 1000,
+                             test_inverse = true, test_logjac = true)
     for _ in 1:N
         x = t isa ScalarTransform ? randn() : randn(dimension(t))
         if t isa ScalarTransform
@@ -37,10 +38,12 @@ function test_transformation(t::AbstractTransform, is_valid_y;
         @test t(x) == y         # callable
         y2, lj = @inferred transform_and_logjac(t, x)
         @test y2 == y
-        if t isa ScalarTransform
-            @test lj ≈ AD_logjac(t, x)
-        else
-            @test lj ≈ AD_logjac(t, x, vec_y)
+        if test_logjac
+            if t isa ScalarTransform
+                @test lj ≈ AD_logjac(t, x)
+            else
+                @test lj ≈ AD_logjac(t, x, vec_y)
+            end
         end
         if test_inverse
             x2 = inverse(t, y)


### PR DESCRIPTION
This PR implements the proposed changes to `UnitVector` in #66 (i.e. Stan's approach). If `x == zeros(n)`, the transformation is technically undefined. Stan handles this by always initializing with jitter. Since we can't control how users initialize, `zeros(n)` is instead mapped deterministically to a valid unit vector.

Along the way, a few tests had to be changed to handle cases like this where the "inverse" is only a right inverse. I also had to add a compat entry for Flux, since Tracker was removed from Flux in v0.10.

Here's a worked example, sampling from the uniform distribution on the circle and sphere:

```julia
using TransformVariables, LogDensityProblems, DynamicHMC, Random, LinearAlgebra
using Plots; plotlyjs()

function sample_post(rng, n, nsamples)
    f(θ) = zero(eltype(θ.x))
    trans = as((x = UnitVector(n),))
    P = TransformedLogDensity(trans, f)
    ∇P = ADgradient(:ForwardDiff, P)
    results = mcmc_with_warmup(rng, ∇P, nsamples; reporter = NoProgressReport())
    posterior = transform.(trans, results.chain)
    x = hcat(first.(posterior)...)
    return x
end

julia> rng = MersenneTwister(42);

julia> x = sample_post(rng, 2, 100000); # sample from circle

julia> all(norm.(eachcol(x)) .≈ 1)
true

julia> θ = (xy -> atan(xy[2], xy[1])).(eachcol(x));  # angle around the circle

julia> histogram(θ);

julia> png("histogram2d.png");

julia> x = sample_post(rng, 3, 100000); # sample from sphere

julia> all(norm.(eachcol(x)) .≈ 1)
true

julia> scatter3d(eachrow(x)...; markersize = 1, markeralpha = 0.2);

julia> png("sample3d.png");
```

This PR produces a uniform distribution on the circle (right), while the existing implementation (left) does not:

<img src="https://user-images.githubusercontent.com/8673634/70371717-a40c1f00-188b-11ea-8bfc-b14e332f8423.png" width=300></img>  <img src="https://user-images.githubusercontent.com/8673634/70371719-a8383c80-188b-11ea-8f4d-fdff2a97f233.png" width=300></img> 

This PR likewise produces a uniform distribution on the sphere (right), while the existing implementation (left) gives a distribution only on the hemisphere:

<img src="https://user-images.githubusercontent.com/8673634/70371809-9e630900-188c-11ea-954b-c3bd82a53435.png" width=300></img>  <img src="https://user-images.githubusercontent.com/8673634/70371806-9b681880-188c-11ea-81b0-898d920fe9ec.png" width=300></img>