### PR TITLE
Replace mapreduce(f,op,...) with reduce(op,map(f,...)) for type stability

### DIFF
--- a/src/aggregation.jl
+++ b/src/aggregation.jl
@@ -97,7 +97,7 @@ $(SIGNATURES)
 
 Sum of the dimension of `transformations`. Utility function, *internal*.
 """
-_sum_dimensions(transformations) = mapreduce(dimension, +, transformations; init = 0)
+_sum_dimensions(transformations) = sum(map(dimension, transformations))
 
 const NTransforms{N} = Tuple{Vararg{AbstractTransform,N}}
 
@@ -181,7 +181,7 @@ internally.
 *Performs no argument validation, caller should do this.*
 """
 _inverse_eltype_tuple(ts::NTransforms, ys::Tuple) =
-    mapreduce(((t, y),) -> inverse_eltype(t, y), promote_type, zip(ts, ys))
+    reduce(promote_type, map(((t, y),) -> inverse_eltype(t, y), zip(ts, ys)))
 
 """
 $(SIGNATURES)

--- a/src/aggregation.jl
+++ b/src/aggregation.jl
@@ -98,6 +98,10 @@ $(SIGNATURES)
 Sum of the dimension of `transformations`. Utility function, *internal*.
 """
 _sum_dimensions(transformations) = reduce(+, map(dimension, transformations), init = 0)
+# NOTE: See https://github.com/tpapp/TransformVariables.jl/pull/80
+#       `map` and `reduce` both have specializations on `Tuple`s that make them type stable
+#       even when the `Tuple` is heterogenous, but that is not currently the case with
+#       `mapreduce`, therefore separate `reduce` and `map` are preferred as a workaround.
 
 const NTransforms{N} = Tuple{Vararg{AbstractTransform,N}}
 
@@ -182,6 +186,10 @@ internally.
 """
 _inverse_eltype_tuple(ts::NTransforms, ys::Tuple) =
     reduce(promote_type, map(((t, y),) -> inverse_eltype(t, y), zip(ts, ys)))
+# NOTE: See https://github.com/tpapp/TransformVariables.jl/pull/80
+#       `map` and `reduce` both have specializations on `Tuple`s that make them type stable
+#       even when the `Tuple` is heterogenous, but that is not currently the case with
+#       `mapreduce`, therefore separate `reduce` and `map` are preferred as a workaround.
 
 """
 $(SIGNATURES)

--- a/src/aggregation.jl
+++ b/src/aggregation.jl
@@ -97,7 +97,7 @@ $(SIGNATURES)
 
 Sum of the dimension of `transformations`. Utility function, *internal*.
 """
-_sum_dimensions(transformations) = sum(map(dimension, transformations))
+_sum_dimensions(transformations) = reduce(+, map(dimension, transformations), init = 0)
 
 const NTransforms{N} = Tuple{Vararg{AbstractTransform,N}}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -504,3 +504,10 @@ end
     @test string(as(Real, 1.0, ∞)) == "as(Real, 1.0, ∞)"
     @test string(as(Real, -∞, 1.0)) == "as(Real, -∞, 1.0)"
 end
+
+@testset "sum dimensions allocations" begin
+    shifted = TransformVariables.ShiftedExp{true,Float64}(0.0)
+    tr = (a = shifted, b = TransformVariables.Identity(), c = shifted, d = shifted, e = shifted, f = shifted)
+    @test iszero(@allocated TransformVariables._sum_dimensions(tr))
+end
+


### PR DESCRIPTION
`mapreduce` tends to be type unstable with hetogenous tuples while `map` and `reduce` are not.

Note the `Union`s before:
```julia
julia> trft
(CL_base = TransformVariables.ShiftedExp{true, Float64}(0.0), CL_logwt = TransformVariables.Identity(), v_base = TransformVariables.ShiftedExp{true, Float64}(0.0), ω_1 = TransformVariables.ShiftedExp{true, Float64}(0.0), ω_2 = TransformVariables.ShiftedExp{true, Float64}(0.0), σ_0 = TransformVariables.ShiftedExp{true, Float64}(0.0))

julia> @code_typed as(trft)
CodeInfo(
1 ── %1  = Base.sle_int(1, 1)::Bool
└───       goto #3 if not %1
2 ── %3  = Base.sle_int(1, 0)::Bool
└───       goto #4
3 ──       nothing::Nothing
4 ┄─ %6  = φ (#2 => %3, #3 => false)::Bool
└───       goto #6 if not %6
5 ──       invoke Base.getindex(()::Tuple, 1::Int64)::Union{}
└───       unreachable
6 ──       goto #7
7 ──       goto #8
8 ──       goto #9
9 ──       goto #10
10 ─ %14 = Base.getfield(transformations, 1)::TransformVariables.ShiftedExp{true, Float64}
└─── %15 = Core.tuple(%14, 2)::Tuple{TransformVariables.ShiftedExp{true, Float64}, Int64}
11 ┄ %16 = φ (#10 => 1, #34 => %75)::Int64
│    %17 = φ (#10 => %15, #34 => %59)::Union{Nothing, Tuple{Union{TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}}, Int64}}
└───       goto #35 if not true
12 ─ %19 = π (%17, Union{Tuple{TransformVariables.Identity, Int64}, Tuple{TransformVariables.ShiftedExp{true, Float64}, Int64}})
│    %20 = (isa)(%19, Tuple{TransformVariables.Identity, Int64})::Bool
└───       goto #14 if not %20
13 ─ %22 = π (%19, Tuple{TransformVariables.Identity, Int64})
│    %23 = Base.getfield(%22, 2, true)::Union{TransformVariables.Identity, Int64}
└───       goto #17
14 ─ %25 = (isa)(%19, Tuple{TransformVariables.ShiftedExp{true, Float64}, Int64})::Bool
└───       goto #16 if not %25
15 ─ %27 = π (%19, Tuple{TransformVariables.ShiftedExp{true, Float64}, Int64})
│    %28 = Base.getfield(%27, 2, true)::Union{Int64, TransformVariables.ShiftedExp{true, Float64}}
└───       goto #17
16 ─       Core.throw(ErrorException("fatal error in type inference (type bound)"))::Union{}
└───       unreachable
17 ┄ %32 = φ (#13 => %23, #15 => %28)::Union{TransformVariables.Identity, Int64, TransformVariables.ShiftedExp{true, Float64}}
│    %33 = Base.iterate::typeof(iterate)
│    %34 = (isa)(%32, TransformVariables.Identity)::Bool
└───       goto #19 if not %34
18 ─ %36 = π (%32, TransformVariables.Identity)
│    %37 = invoke %33(_2::NamedTuple{(:CL_base, :CL_logwt, :v_base, :ω_1, :ω_2, :σ_0), Tuple{TransformVariables.ShiftedExp{true, Float64}, TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}}}, %36::TransformVariables.Identity)::Union{Nothing, Tuple{Union{TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}}, Int64}}
└───       goto #27
19 ─ %39 = (isa)(%32, Int64)::Bool
└───       goto #24 if not %39
20 ─ %41 = π (%32, Int64)
│    %42 = Base.slt_int(6, %41)::Bool
└───       goto #22 if not %42
21 ─ %44 = Base.nothing::Nothing
└───       goto #23
22 ─ %46 = Base.getfield(transformations, %41)::Union{TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}}
│    %47 = Base.add_int(%41, 1)::Int64
│    %48 = Core.tuple(%46, %47)::Tuple{Union{TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}}, Int64}
└───       goto #23
23 ┄ %50 = φ (#21 => %44, #22 => %48)::Union{Nothing, Tuple{Union{TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}}, Int64}}
└───       goto #27
24 ─ %52 = (isa)(%32, TransformVariables.ShiftedExp{true, Float64})::Bool
└───       goto #26 if not %52
25 ─ %54 = π (%32, TransformVariables.ShiftedExp{true, Float64})
│    %55 = invoke %33(_2::NamedTuple{(:CL_base, :CL_logwt, :v_base, :ω_1, :ω_2, :σ_0), Tuple{TransformVariables.ShiftedExp{true, Float64}, TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}}}, %54::TransformVariables.ShiftedExp{true, Float64})::Union{Nothing, Tuple{Union{TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}}, Int64}}
└───       goto #27
26 ─       Core.throw(ErrorException("fatal error in type inference (type bound)"))::Union{}
└───       unreachable
27 ┄ %59 = φ (#18 => %37, #23 => %50, #25 => %55)::Union{Nothing, Tuple{Union{TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}}, Int64}}
│    %60 = (%59 === Base.nothing)::Bool
└───       goto #29 if not %60
28 ─       goto #35
29 ─ %63 = π (%59, Tuple{Union{TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}}, Int64})
│    %64 = Base.getfield(%63, 1, true)::Union{TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}}
│    %65 = (isa)(%64, TransformVariables.Identity)::Bool
└───       goto #31 if not %65
30 ─ %67 = Base.add_int(%16, 1)::Int64
└───       goto #34
31 ─ %69 = (isa)(%64, TransformVariables.ShiftedExp{true, Float64})::Bool
└───       goto #33 if not %69
32 ─ %71 = Base.add_int(%16, 1)::Int64
└───       goto #34
33 ─       Core.throw(ErrorException("fatal error in type inference (type bound)"))::Union{}
└───       unreachable
34 ┄ %75 = φ (#30 => %67, #32 => %71)::Int64
└───       goto #11
35 ┄       goto #36
36 ─       goto #37
37 ─       goto #38
38 ─       goto #39
39 ─       goto #40
40 ─       goto #41
41 ─       goto #42
42 ─       goto #43
43 ─ %85 = %new(TransformVariables.TransformTuple{NamedTuple{(:CL_base, :CL_logwt, :v_base, :ω_1, :ω_2, :σ_0), Tuple{TransformVariables.ShiftedExp{true, Float64}, TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}}}}, transformations, %16)::TransformVariables.TransformTuple{NamedTuple{(:CL_base, :CL_logwt, :v_base, :ω_1, :ω_2, :σ_0), Tuple{TransformVariables.ShiftedExp{true, Float64}, TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}}}}
└───       goto #44
44 ─       return %85
) => TransformVariables.TransformTuple{NamedTuple{(:CL_base, :CL_logwt, :v_base, :ω_1, :ω_2, :σ_0), Tuple{TransformVariables.ShiftedExp{true, Float64}, TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}}}}
```
versus after
```julia
 @code_typed as(trft)
CodeInfo(
1 ──       nothing::Nothing
2 ┄─ %2  = φ (#1 => 1, #8 => %16)::Int64
│    %3  = φ (#1 => 2, #8 => %11)::Int64
└───       goto #9 if not true
3 ── %5  = Base.slt_int(6, %3)::Bool
└───       goto #5 if not %5
4 ──       goto #6
5 ── %8  = Base.getfield($(QuoteNode((CL_base = 1, CL_logwt = 1, v_base = 1, ω_1 = 1, ω_2 = 1, σ_0 = 1))), %3)::Int64
│    %9  = Base.add_int(%3, 1)::Int64
└───       goto #6
6 ┄─ %11 = φ (#5 => %9)::Int64
│    %12 = φ (#4 => true, #5 => false)::Bool
│    %13 = φ (#5 => %8)::Int64
└───       goto #8 if not %12
7 ──       goto #9
8 ── %16 = Base.add_int(%2, %13)::Int64
└───       goto #2
9 ┄─       goto #10
10 ─       goto #11
11 ─       goto #12
12 ─       goto #13
13 ─       goto #14
14 ─       goto #15
15 ─       goto #16
16 ─       goto #17
17 ─       goto #18
18 ─       goto #19
19 ─       goto #20
20 ─       goto #21
21 ─ %30 = %new(TransformVariables.TransformTuple{NamedTuple{(:CL_base, :CL_logwt, :v_base, :ω_1, :ω_2, :σ_0), Tuple{TransformVariables.ShiftedExp{true, Float64}, TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}}}}, transformations, %2)::TransformVariables.TransformTuple{NamedTuple{(:CL_base, :CL_logwt, :v_base, :ω_1, :ω_2, :σ_0), Tuple{TransformVariables.ShiftedExp{true, Float64}, TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}}}}
└───       goto #22
22 ─       return %30
) => TransformVariables.TransformTuple{NamedTuple{(:CL_base, :CL_logwt, :v_base, :ω_1, :ω_2, :σ_0), Tuple{TransformVariables.ShiftedExp{true, Float64}, TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}}}}
```
Benchmarks before and after:
```julia
julia> @btime as($trft) # before
  393.995 ns (19 allocations: 544 bytes)
TransformVariables.TransformTuple{NamedTuple{(:CL_base, :CL_logwt, :v_base, :ω_1, :ω_2, :σ_0), Tuple{TransformVariables.ShiftedExp{true, Float64}, TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}}}}((CL_base = TransformVariables.ShiftedExp{true, Float64}(0.0), CL_logwt = TransformVariables.Identity(), v_base = TransformVariables.ShiftedExp{true, Float64}(0.0), ω_1 = TransformVariables.ShiftedExp{true, Float64}(0.0), ω_2 = TransformVariables.ShiftedExp{true, Float64}(0.0), σ_0 = TransformVariables.ShiftedExp{true, Float64}(0.0)), 6)

julia> @btime as($trft) # after
  1.649 ns (0 allocations: 0 bytes)
TransformVariables.TransformTuple{NamedTuple{(:CL_base, :CL_logwt, :v_base, :ω_1, :ω_2, :σ_0), Tuple{TransformVariables.ShiftedExp{true, Float64}, TransformVariables.Identity, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}, TransformVariables.ShiftedExp{true, Float64}}}}((CL_base = TransformVariables.ShiftedExp{true, Float64}(0.0), CL_logwt = TransformVariables.Identity(), v_base = TransformVariables.ShiftedExp{true, Float64}(0.0), ω_1 = TransformVariables.ShiftedExp{true, Float64}(0.0), ω_2 = TransformVariables.ShiftedExp{true, Float64}(0.0), σ_0 = TransformVariables.ShiftedExp{true, Float64}(0.0)), 6)
```