### PR TITLE
Support ChangesOfVariables and InverseFunctions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,10 @@ version = "0.4.1"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -14,8 +16,10 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 ArgCheck = "1, 2.0"
+ChangesOfVariables = "0.1"
 DocStringExtensions = "0.8"
 ForwardDiff = "0.10"
+InverseFunctions = "0.1"
 UnPack = "1"
 julia = "^1.3"
 

--- a/src/TransformVariables.jl
+++ b/src/TransformVariables.jl
@@ -7,6 +7,9 @@ using LinearAlgebra: UpperTriangular, logabsdet
 using UnPack: @unpack
 using Random: AbstractRNG, GLOBAL_RNG
 
+import ChangesOfVariables
+import InverseFunctions
+
 include("utilities.jl")
 include("generic.jl")
 include("scalar.jl")

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -143,6 +143,8 @@ end
 
 transform(t) = CallableTransform(t)
 
+ChangesOfVariables.with_logabsdet_jacobian(f::CallableTransform, x) = transform_and_logjac(f.t, x)
+
 """
 $(TYPEDEF)
 
@@ -158,8 +160,12 @@ function Base.show(io::IO, f::CallableInverse)
 end
 
 inverse(f::CallableInverse) = CallableTransform(f.t)
+InverseFunctions.inverse(f::CallableInverse) = CallableTransform(f.t)
 
 inverse(f::CallableTransform) = CallableInverse(f.t)
+InverseFunctions.inverse(f::CallableTransform) = CallableInverse(f.t)
+
+ChangesOfVariables.with_logabsdet_jacobian(f::CallableInverse, x) = inverse_and_logjac(f.t, x)
 
 """
 `$(FUNCTIONNAME)(t, y)`

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using LogDensityProblems: logdensity, logdensity_and_gradient
 using TransformVariables:
     AbstractTransform, ScalarTransform, VectorTransform, ArrayTransform,
     unit_triangular_dimension, logistic, logistic_logjac, logit, inverse_and_logjac
+import ChangesOfVariables, InverseFunctions
 
 const CIENV = get(ENV, "CI", "") == "true"
 
@@ -529,4 +530,22 @@ end
     @test transform(t)(x) == transform(t, x)
     y = transform(t, x)
     @test inverse(t)(y) == inverse(t, y) == inverse(transform(t))(y) ≈ x
+end
+
+
+@testset "ChangesOfVariables" begin
+    t = as(Real, 1.0, 3.0)
+    f = TransformVariables.CallableTransform(t)
+    inv_f = TransformVariables.CallableInverse(t)
+    ChangesOfVariables.test_with_logabsdet_jacobian(f, -4.2, ForwardDiff.derivative)
+    ChangesOfVariables.test_with_logabsdet_jacobian(inv_f, 1.7, ForwardDiff.derivative)
+end
+
+
+@testset "InverseFunctions" begin
+    t = as(Real, 1.0, 3.0)
+    f = TransformVariables.CallableTransform(t)
+    inv_f = TransformVariables.CallableInverse(t)
+    InverseFunctions.test_inverse(f, -4.2)
+    InverseFunctions.test_inverse(inv_f, 1.7)
 end


### PR DESCRIPTION
This PR adds support for [JuliaMath/ChangesOfVariables](https://github.com/JuliaMath/ChangesOfVariables.jl) and [JuliaMath/InverseFunctions](https://github.com/JuliaMath/InverseFunctions.jl). Both are very lightweight, dependency-free, low-bias packages designed to enable composability of packages that provide/implement or use variable transformation capabilities.

Specifically, this PR adds support for `ChangesOfVariables.test_with_logabsdet_jacobian` and `InverseFunctions.inverse`. Package like StatsFuns and LogExpFunctions already support one or both of them (JuliaStats/LogExpFunctions.jl#29, JuliaStats/LogExpFunctions.jl#30, JuliaStats/StatsFuns.jl#130). I think it would be awesome if TransformVariables would join the club.

This PR has no impact on the load time of TransformVariables

```julia
# Current master branch:
julia> @time using TransformVariables
  1.104098 seconds (3.20 M allocations: 229.310 MiB, 2.51% gc time, 39.71% compilation time)
```

```julia
# This PR:
julia> @time using TransformVariables
1.105833 seconds (3.20 M allocations: 229.336 MiB, 2.15% gc time, 37.48% compilation time)
```

CC @devmotion
