### PR TITLE
Use LogExpFunctions instead of own implementations of logistic and logit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TransformVariables"
 uuid = "84d833dd-6860-57f9-a1a7-6da5db126cff"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.6.0"
+version = "0.5.99"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
@@ -10,6 +10,7 @@ DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"

--- a/src/TransformVariables.jl
+++ b/src/TransformVariables.jl
@@ -6,6 +6,7 @@ import ForwardDiff
 using LinearAlgebra: UpperTriangular, logabsdet
 using UnPack: @unpack
 using Random: AbstractRNG, GLOBAL_RNG
+using LogExpFunctions
 
 import ChangesOfVariables
 import InverseFunctions

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -2,14 +2,10 @@
 ### logistic and logit
 ###
 
-logistic(x::Real) = inv(one(x) + exp(-x))
-
 function logistic_logjac(x::Real)
     mx = -abs(x)
     mx - 2*log1p(exp(mx))
 end
-
-logit(x::Real) = log(x / (one(x) - x))
 
 logit_logjac(y) = -log(y) - log1p(-y)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -399,20 +399,23 @@ end
     v = logdensity(P, x)
     g = ForwardDiff.gradient(x -> logdensity(P, x), x)
 
-    # ForwardDiff
-    P1 = ADgradient(:ForwardDiff, P)
-    @test v == logdensity(P1, x)
-    v1, g1 = @inferred logdensity_and_gradient(P1, x)
-    @test v1 == v
-    @test g1 ≈ g
+    @testset "ForwardDiff" begin
+        P1 = ADgradient(:ForwardDiff, P)
+        @test v == logdensity(P1, x)
+        v1, g1 = @inferred logdensity_and_gradient(P1, x)
+        @test v1 == v
+        @test g1 ≈ g
 
-    # Tracker
-    P2 = ADgradient(:Tracker, P)
-    v2, g2 = @inferred logdensity_and_gradient(P2, x)
-    @test v2 == v
-    @test g2 ≈ g
+        xd = ForwardDiff.Dual(-800.0, 1.0)
+        @test first(ForwardDiff.partials(transform(as(Real, 0.0, 1.0), xd))) == 0.0
+    end
 
-
+    @testset "Tracker" begin
+        P2 = ADgradient(:Tracker, P)
+        v2, g2 = @inferred logdensity_and_gradient(P2, x)
+        @test v2 == v
+        @test g2 ≈ g
+    end
 end
 
 # if VERSION ≥ v"1.1"


### PR DESCRIPTION
With the current version of logistic
```julia
xd = ForwardDiff.Dual(-800.0, 1.0)
first(ForwardDiff.partials(transform(as(Real, 0.0, 1.0), xd)))
```
returns `NaN`.

(Notice that I've set the version to 0.5.99 to work around https://github.com/tpapp/LogDensityProblems.jl/issues/80)