### PR TITLE
Initialize arrays with NaN for easier error detection

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -280,7 +280,7 @@ function transform_and_logjac(t::VectorTransform, x::AbstractVector)
 end
 
 function inverse(t::VectorTransform, y)
-    inverse!(Vector{inverse_eltype(t, y)}(undef, dimension(t)), t, y)
+    inverse!(fill(inverse_eltype(t, y)(NaN), dimension(t)), t, y)
 end
 
 """

--- a/src/special_arrays.jl
+++ b/src/special_arrays.jl
@@ -52,7 +52,7 @@ function transform_with(flag::LogJacFlag, t::UnitVector, x::AbstractVector, inde
     @unpack n = t
     T = extended_eltype(x)
     r = one(T)
-    y = Vector{T}(undef, n)
+    y = fill(T(NaN), n)
     ℓ = logjac_zero(flag, T)
     @inbounds for i in 1:(n - 1)
         xi = x[index]
@@ -103,7 +103,7 @@ function transform_with(flag::LogJacFlag, t::UnitSimplex, x::AbstractVector, ind
 
     ℓ = logjac_zero(flag, T)
     stick = one(T)
-    y = Vector{T}(undef, n)
+    y = fill(T(NaN), n)
     @inbounds for i in 1:n-1
         xi = x[index]
         index += 1
@@ -177,7 +177,7 @@ function transform_with(flag::LogJacFlag, t::CorrCholeskyFactor, x::AbstractVect
     @unpack n = t
     T = extended_eltype(x)
     ℓ = logjac_zero(flag, T)
-    U = Matrix{T}(undef, n, n)
+    U = fill(T(NaN), n, n)
     @inbounds for col in 1:n
         r = one(T)
         for row in 1:(col-1)

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -59,7 +59,7 @@ Elements (strictly) above the diagonal as a vector.
 function vec_above_diagonal(U::UpperTriangular{T}) where T
     n = size(U, 1)
     index = 1
-    x = Vector{T}(undef, unit_triangular_dimension(n))
+    x = fill(T(NaN), unit_triangular_dimension(n))
     for col in 1:n
         for row in 1:(col-1)
             x[index] = U[row, col]


### PR DESCRIPTION
The `NaN`s will make it immediately obvious when some memory hasn't been properly set. I had a case where zero was the correct value so most often the random memory happened to have the correct value. Except on CI where it received memory that made the tests fail.