### PR TITLE
no `zip` in `_inverse_eltype_tuple`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TransformVariables"
 uuid = "84d833dd-6860-57f9-a1a7-6da5db126cff"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/aggregation.jl
+++ b/src/aggregation.jl
@@ -185,7 +185,7 @@ internally.
 *Performs no argument validation, caller should do this.*
 """
 _inverse_eltype_tuple(ts::NTransforms, ys::Tuple) =
-    reduce(promote_type, map(((t, y),) -> inverse_eltype(t, y), zip(ts, ys)))
+    reduce(promote_type, map(inverse_eltype, ts, ys))
 # NOTE: See https://github.com/tpapp/TransformVariables.jl/pull/80
 #       `map` and `reduce` both have specializations on `Tuple`s that make them type stable
 #       even when the `Tuple` is heterogenous, but that is not currently the case with

--- a/src/aggregation.jl
+++ b/src/aggregation.jl
@@ -176,6 +176,13 @@ function transform_tuple(flag::LogJacFlag, tt::NTransforms, x, index)
     _transform_tuple(flag, x, index, tt)
 end
 
+# _nolimitmap is to avoid the recursion limit at 16 for `map` that caused
+# problems in older Julia versions, e.g. 1.3
+@inline _nolimitmap(f::F, ::Tuple{}, ::Tuple{}) where {F} = ()
+@inline function _nolimitmap(f::F, x::Tuple{T,Vararg}, y::Tuple{S,Vararg}) where {F, T, S}
+  (f(first(x), first(y)), _nolimitmap(f, Base.tail(x), Base.tail(y))...)
+end
+
 """
 $(SIGNATURES)
 
@@ -185,7 +192,7 @@ internally.
 *Performs no argument validation, caller should do this.*
 """
 _inverse_eltype_tuple(ts::NTransforms, ys::Tuple) =
-    reduce(promote_type, map(inverse_eltype, ts, ys))
+    reduce(promote_type, _nolimitmap(inverse_eltype, ts, ys))
 # NOTE: See https://github.com/tpapp/TransformVariables.jl/pull/80
 #       `map` and `reduce` both have specializations on `Tuple`s that make them type stable
 #       even when the `Tuple` is heterogenous, but that is not currently the case with

--- a/src/aggregation.jl
+++ b/src/aggregation.jl
@@ -176,13 +176,6 @@ function transform_tuple(flag::LogJacFlag, tt::NTransforms, x, index)
     _transform_tuple(flag, x, index, tt)
 end
 
-# _nolimitmap is to avoid the recursion limit at 16 for `map` that caused
-# problems in older Julia versions, e.g. 1.3
-@inline _nolimitmap(f::F, ::Tuple{}, ::Tuple{}) where {F} = ()
-@inline function _nolimitmap(f::F, x::Tuple{T,Vararg}, y::Tuple{S,Vararg}) where {F, T, S}
-  (f(first(x), first(y)), _nolimitmap(f, Base.tail(x), Base.tail(y))...)
-end
-
 """
 $(SIGNATURES)
 
@@ -192,7 +185,7 @@ internally.
 *Performs no argument validation, caller should do this.*
 """
 _inverse_eltype_tuple(ts::NTransforms, ys::Tuple) =
-    reduce(promote_type, _nolimitmap(inverse_eltype, ts, ys))
+    reduce(promote_type, map(inverse_eltype, ts, ys))
 # NOTE: See https://github.com/tpapp/TransformVariables.jl/pull/80
 #       `map` and `reduce` both have specializations on `Tuple`s that make them type stable
 #       even when the `Tuple` is heterogenous, but that is not currently the case with

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -218,7 +218,7 @@ end
     x = random_arg(tt)
     y = @inferred transform(tt, x)
     @test inverse(tt, y) ≈ x
-    TransformVariables.inverse_eltype(tt, y)
+    @test @inferred(TransformVariables.inverse_eltype(tt, y)) === Float64
     index = 0
     ljacc = 0.0
     for (i, t) in enumerate((t1, t2, t3))
@@ -537,6 +537,15 @@ end
     shifted = TransformVariables.ShiftedExp{true,Float64}(0.0)
     tr = (a = shifted, b = TransformVariables.Identity(), c = shifted, d = shifted, e = shifted, f = shifted)
     @test iszero(@allocated TransformVariables._sum_dimensions(tr))
+end
+
+@testset "inverse_eltype allocations" begin
+  trf = as((x0 = TransformVariables.ShiftedExp{true, Float32}(0f0), x1 = TransformVariables.Identity(), x2 = UnitSimplex(7), x3 = TransformVariables.CorrCholeskyFactor(5), x4 = as(Real, -∞, 1), x5 = as(Array, 10, 2), x6 = as(Array, as𝕀, 10), x7 = as((a = asℝ₊, b = as𝕀)), x8 = TransformVariables.UnitVector(10), x9 = TransformVariables.ShiftedExp{true, Float32}(0f0), x10 = TransformVariables.ShiftedExp{true, Float32}(0f0), x11 = TransformVariables.ShiftedExp{true, Float32}(0f0), x12 = TransformVariables.ShiftedExp{true, Float32}(0f0), x13 = TransformVariables.Identity(), x14 = TransformVariables.ShiftedExp{true, Float32}(0f0), x15 = TransformVariables.ShiftedExp{true, Float32}(0f0), x16 = TransformVariables.ShiftedExp{true, Float32}(0f0), x17 = TransformVariables.ShiftedExp{true, Float64}(0.0)));
+  
+  vx = randn(@inferred(TransformVariables.dimension(trf)));
+  x = TransformVariables.transform(trf, vx);
+  @test @inferred(TransformVariables.inverse_eltype(trf, x)) === Float64
+  
 end
 
 ####

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -539,13 +539,15 @@ end
     @test iszero(@allocated TransformVariables._sum_dimensions(tr))
 end
 
+if VERSION >= v"1.7"
 @testset "inverse_eltype allocations" begin
-  trf = as((x0 = TransformVariables.ShiftedExp{true, Float32}(0f0), x1 = TransformVariables.Identity(), x2 = UnitSimplex(7), x3 = TransformVariables.CorrCholeskyFactor(5), x4 = as(Real, -∞, 1), x5 = as(Array, 10, 2), x6 = as(Array, as𝕀, 10), x7 = as((a = asℝ₊, b = as𝕀)), x8 = TransformVariables.UnitVector(10), x9 = TransformVariables.ShiftedExp{true, Float32}(0f0), x10 = TransformVariables.ShiftedExp{true, Float32}(0f0), x11 = TransformVariables.ShiftedExp{true, Float32}(0f0), x12 = TransformVariables.ShiftedExp{true, Float32}(0f0), x13 = TransformVariables.Identity(), x14 = TransformVariables.ShiftedExp{true, Float32}(0f0), x15 = TransformVariables.ShiftedExp{true, Float32}(0f0), x16 = TransformVariables.ShiftedExp{true, Float32}(0f0), x17 = TransformVariables.ShiftedExp{true, Float64}(0.0)));
+    trf = as((x0 = TransformVariables.ShiftedExp{true, Float32}(0f0), x1 = TransformVariables.Identity(), x2 = UnitSimplex(7), x3 = TransformVariables.CorrCholeskyFactor(5), x4 = as(Real, -∞, 1), x5 = as(Array, 10, 2), x6 = as(Array, as𝕀, 10), x7 = as((a = asℝ₊, b = as𝕀)), x8 = TransformVariables.UnitVector(10), x9 = TransformVariables.ShiftedExp{true, Float32}(0f0), x10 = TransformVariables.ShiftedExp{true, Float32}(0f0), x11 = TransformVariables.ShiftedExp{true, Float32}(0f0), x12 = TransformVariables.ShiftedExp{true, Float32}(0f0), x13 = TransformVariables.Identity(), x14 = TransformVariables.ShiftedExp{true, Float32}(0f0), x15 = TransformVariables.ShiftedExp{true, Float32}(0f0), x16 = TransformVariables.ShiftedExp{true, Float32}(0f0), x17 = TransformVariables.ShiftedExp{true, Float64}(0.0)));
   
-  vx = randn(@inferred(TransformVariables.dimension(trf)));
-  x = TransformVariables.transform(trf, vx);
-  @test @inferred(TransformVariables.inverse_eltype(trf, x)) === Float64
+    vx = randn(@inferred(TransformVariables.dimension(trf)));
+    x = TransformVariables.transform(trf, vx);
+    @test @inferred(TransformVariables.inverse_eltype(trf, x)) === Float64
   
+end
 end
 
 ####


### PR DESCRIPTION
The added test will fail on the current master and the latest release.
On 0.6.1, I get:
```julia
julia> using TransformVariables, Test

julia> trf = as((x0 = TransformVariables.ShiftedExp{true, Float32}(0f0), x1 = TransformVariables.Identity(), x2 = UnitSimplex(7), x3 = TransformVariables.CorrCholeskyFactor(5), x4 = as(Real, -∞, 1), x5 = as(Array, 10, 2), x6 = as(Array, as𝕀, 10), x7 = as((a = asℝ₊, b = as𝕀)), x8 = TransformVariables.UnitVector(10), x9 = TransformVariables.ShiftedExp{true, Float32}(0f0), x10 = TransformVariables.ShiftedExp{true, Float32}(0f0), x11 = TransformVariables.ShiftedExp{true, Float32}(0f0), x12 = TransformVariables.ShiftedExp{true, Float32}(0f0), x13 = TransformVariables.Identity(), x14 = TransformVariables.ShiftedExp{true, Float32}(0f0), x15 = TransformVariables.ShiftedExp{true, Float32}(0f0), x16 = TransformVariables.ShiftedExp{true, Float32}(0f0), x17 = TransformVariables.ShiftedExp{true, Float64}(0.0)));

julia> vx = randn(@inferred(TransformVariables.dimension(trf)));

julia> x = TransformVariables.transform(trf, vx);

julia> @test @inferred(TransformVariables.inverse_eltype(trf, x)) === Float64
Error During Test at REPL[10]:1
  Test threw exception
  Expression: #= REPL[10]:1 =# @inferred(TransformVariables.inverse_eltype(trf, x)) === Float64
  return type Type{Float64} does not match inferred return type Any
  Stacktrace:
    [1] error(s::String)
      @ Base ./error.jl:35
    [2] top-level scope
      @ ~/Documents/languages/juliarelease/usr/share/julia/stdlib/v1.8/Test/src/Test.jl:464
    [3] eval
      @ ./boot.jl:368 [inlined]
    [4] eval_user_input(ast::Any, backend::REPL.REPLBackend)
      @ REPL ~/Documents/languages/juliarelease/usr/share/julia/stdlib/v1.8/REPL/src/REPL.jl:151
    [5] repl_backend_loop(backend::REPL.REPLBackend)
      @ REPL ~/Documents/languages/juliarelease/usr/share/julia/stdlib/v1.8/REPL/src/REPL.jl:247
    [6] start_repl_backend(backend::REPL.REPLBackend, consumer::Any)
      @ REPL ~/Documents/languages/juliarelease/usr/share/julia/stdlib/v1.8/REPL/src/REPL.jl:232
    [7] run_repl(repl::REPL.AbstractREPL, consumer::Any; backend_on_current_task::Bool)
      @ REPL ~/Documents/languages/juliarelease/usr/share/julia/stdlib/v1.8/REPL/src/REPL.jl:369
    [8] run_repl(repl::REPL.AbstractREPL, consumer::Any)
      @ REPL ~/Documents/languages/juliarelease/usr/share/julia/stdlib/v1.8/REPL/src/REPL.jl:356
    [9] (::Base.var"#964#966"{Bool, Bool, Bool})(REPL::Module)
      @ Base ./client.jl:419
   [10] #invokelatest#2
      @ ./essentials.jl:729 [inlined]
   [11] invokelatest
      @ ./essentials.jl:727 [inlined]
   [12] run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_file::Bool, color_set::Bool)
      @ Base ./client.jl:404
   [13] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:318
   [14] _start()
      @ Base ./client.jl:522
ERROR: There was an error during testing
```