### PR TITLE
Deprecate random_arg and random_value.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TransformVariables"
 uuid = "84d833dd-6860-57f9-a1a7-6da5db126cff"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -57,11 +57,6 @@ inverse_eltype
 transform_logdensity
 ```
 
-```@docs
-random_arg
-random_value
-```
-
 # Defining transformations
 
 ## The `as` constructor and aggregations

--- a/src/TransformVariables.jl
+++ b/src/TransformVariables.jl
@@ -18,5 +18,6 @@ include("special_arrays.jl")
 include("constant.jl")
 include("aggregation.jl")
 include("custom.jl")
+include("deprecated.jl")
 
 end # module

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,3 @@
+Base.@deprecate random_arg(t::ScalarTransform; kwargs...) randn()
+Base.@deprecate random_arg(t::VectorTransform; kwargs...) randn(dimension(t))
+Base.@deprecate random_value(t::AbstractTransform; kwargs) transform(t, randn(dimension(t)))

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1,5 +1,5 @@
 export dimension, transform, transform_and_logjac, transform_logdensity, inverse, inverse!,
-    inverse_eltype, as, random_arg, random_value
+    inverse_eltype, as
 
 ###
 ### log absolute Jacobian determinant
@@ -282,25 +282,3 @@ end
 function inverse(t::VectorTransform, y)
     inverse!(Vector{inverse_eltype(t, y)}(undef, dimension(t)), t, y)
 end
-
-"""
-$(SIGNATURES)
-
-A random argument for a transformation.
-
-# Keyword arguments
-
-$(_RANDOM_REALS_KWARGS_DOC)
-"""
-random_arg(x::VectorTransform; kwargs...) = random_reals(dimension(x); kwargs...)
-
-"""
-$(SIGNATURES)
-
-Random value from a transformation.
-
-# Keyword arguments
-
-$(_RANDOM_REALS_KWARGS_DOC)
-"""
-random_value(t::AbstractTransform; kwargs...) = transform(t, random_arg(t; kwargs...))

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -28,8 +28,6 @@ end
 
 inverse_eltype(t::ScalarTransform, y::T) where {T <: Real} = float(T)
 
-random_arg(t::ScalarTransform; kwargs...) = random_real(; kwargs...)
-
 ####
 #### identity
 ####

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -37,37 +37,3 @@ function extended_eltype(::Type{S}) where S
 end
 
 extended_eltype(x::T) where T = extended_eltype(T)
-
-####
-#### random values
-####
-
-"Shared part of docstrings for keyword arguments of or passed to [`random_reals`](@ref)."
-const _RANDOM_REALS_KWARGS_DOC = """
-A standard multivaritate normal or Cauchy is used, depending on `cauchy`, then scaled with
-`scale`. `rng` is the random number generator used.
-"""
-
-_random_reals_scale(rng::AbstractRNG, scale::Real, cauchy::Bool) =
-    cauchy ? scale / abs2(randn(rng)) : scale * 1.0
-
-"""
-$(SIGNATURES)
-
-Random real number.
-
-$(_RANDOM_REALS_KWARGS_DOC)
-"""
-random_real(; scale::Real = 1, cauchy::Bool = false, rng::AbstractRNG = GLOBAL_RNG) =
-    randn(rng) * _random_reals_scale(rng, scale, cauchy)
-
-"""
-$(SIGNATURES)
-
-Random vector in ``ℝⁿ``.
-
-$(_RANDOM_REALS_KWARGS_DOC)
-"""
-random_reals(n::Integer; scale::Real = 1, cauchy::Bool = false,
-             rng::AbstractRNG = GLOBAL_RNG) =
-                 randn(rng, n) .* _random_reals_scale(rng, scale, cauchy)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -373,24 +373,6 @@ end
     @test transform_and_logjac(t, x) == transform_and_logjac(t, xo)
 end
 
-@testset "random value" begin
-    t1 = asℝ
-    t2 = CorrCholeskyFactor(7)
-    t3 = UnitVector(3)
-    tn = as((a = t1, b = t2, c = t3))
-    y = random_value(tn)
-    @test y isa NamedTuple{(:a, :b, :c), <: Tuple{Float64, AbstractMatrix, Vector}}
-    @test size(y.b) == (7, 7)
-    @test size(y.c) == (3, )
-end
-
-@testset "random arg" begin
-    t = as(Array, 5)
-    for _ in 1:1000
-        @test sum(abs2, random_arg(t; cauchy = false, scale = 1.0)) ≤ 100
-    end
-end
-
 ####
 #### AD compatibility tests
 ####

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -12,6 +12,14 @@ AD_logjac(t::ScalarTransform, x) =
 """
 $(SIGNATURES)
 
+A random input, for testing.
+"""
+random_arg(t::ScalarTransform) = randn()
+random_arg(t::VectorTransform) = randn(dimension(t))
+
+"""
+$(SIGNATURES)
+
 Test transformation `t` with random values, `N` times.
 
 `is_valid_y` checks the result of the transformation.
@@ -24,13 +32,7 @@ automatic differentiation.
 function test_transformation(t::AbstractTransform, is_valid_y;
                              vec_y = identity, N = 1000, test_inverse = true)
     for _ in 1:N
-        x = t isa ScalarTransform ? randn() : randn(dimension(t))
-        if t isa ScalarTransform
-            @test random_arg(t) isa Float64
-        else
-            y = random_arg(t)
-            @test y isa Vector{Float64} && length(y) == dimension(t)
-        end
+        x = random_arg(t)
         x isa ScalarTransform && @test dimension(x) == 1
         y = @inferred transform(t, x)
         @test is_valid_y(y)

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -46,9 +46,9 @@ function test_transformation(t::AbstractTransform, is_valid_y;
         end
         if test_inverse
             x2 = inverse(t, y)
-            @test x ≈ x2
+            @test x ≈ x2 atol = 1e-6
             ι = inverse(t)
-            @test x ≈ ι(y)
+            @test x2 == ι(y)
         end
     end
 end


### PR DESCRIPTION
They were rather ad-hoc anyway for transformations (which have no
associated measure) and badly implemented (not using RNG). They have a
better home in LogDensityProblems, but the API doesn't expose them. A
version was retained for testing.