### PR TITLE
Minor fixes for static correlation Cholesky factor.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TransformVariables"
 uuid = "84d833dd-6860-57f9-a1a7-6da5db126cff"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/aggregation.jl
+++ b/src/aggregation.jl
@@ -128,7 +128,7 @@ function transform_with(flag::LogJacFlag, transformation::StaticArrayTransformat
                   ℓ += ℓΔ
                   y
               end
-              for _ in 1:D), ℓ
+              for _ in 1:D), ℓ, index
 end
 
 function inverse_eltype(transformation::Union{ArrayTransformation,StaticArrayTransformation},


### PR DESCRIPTION
- missing continuation index
- fix AD with ReverseDiff (its tracker type is not a bits type)