### PR TITLE
Fix as(SVector{1}) transformations.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,6 @@ jobs:
         version:
           - '1.6' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
-          - 'nightly'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TransformVariables"
 uuid = "84d833dd-6860-57f9-a1a7-6da5db126cff"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.8.7"
+version = "0.8.8"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "~0.27"
+Documenter = "1"

--- a/src/aggregation.jl
+++ b/src/aggregation.jl
@@ -197,6 +197,7 @@ function transform_with(flag::LogJacFlag, transformation::StaticArrayTransformat
     # NOTE this is a fix for #112, enforcing types taken from the transformation of the
     # first element.
     y1, ℓ1, index1 = transform_with(flag, inner_transformation, x, index)
+    D == 1 && return SArray{S}(y1), ℓ1, index1
     L = typeof(ℓ1)
     let ℓ::L = ℓ1, index::Int = index1
         function _f(_)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -362,7 +362,7 @@ generating graphs and data summaries.
 
 Transformations may provide a heuristic label.
 
-Transformations should implement [`_domain_label`](@ref).
+Transformations should implement `_domain_label`.
 
 # Example
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -643,6 +643,7 @@ end
 
 @testset "static arrays inference" begin
     @test @inferred transform_with(NOLOGJAC, as(SVector{3, Float64}), zeros(3), 1) == (SVector(0.0, 0.0, 0.0), NOLOGJAC, 4)
+    @test @inferred transform_with(NOLOGJAC, as(SVector{1, Float64}), zeros(1), 1) == (SVector(0.0), NOLOGJAC, 2)
 end
 
 @testset "view transformations" begin


### PR DESCRIPTION
This corner case was missed in #113.