### PR TITLE
Support NamedTuple of different ordering

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TransformVariables"
 uuid = "84d833dd-6860-57f9-a1a7-6da5db126cff"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.8.10"
+version = "0.8.11"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/aggregation.jl
+++ b/src/aggregation.jl
@@ -391,14 +391,18 @@ end
 
 function inverse_eltype(tt::TransformTuple{<:NamedTuple}, y::NamedTuple)
     @unpack transformations = tt
-    @argcheck keys(transformations) == keys(y)
-    _inverse_eltype_tuple(values(transformations), values(y))
+    @argcheck _same_set_of_names(transformations, y)
+    _inverse_eltype_tuple(values(transformations), values(NamedTuple{keys(transformations)}(y)))
 end
 
 function inverse_at!(x::AbstractVector, index, tt::TransformTuple{<:NamedTuple}, y::NamedTuple)
     @unpack transformations = tt
-    @argcheck keys(transformations) == keys(y)
-    _inverse!_tuple(x, index, values(transformations), values(y))
+    @argcheck _same_set_of_names(transformations, y)
+    _inverse!_tuple(x, index, values(transformations), values(NamedTuple{keys(transformations)}(y)))
+end
+
+function _same_set_of_names(x::NamedTuple, y::NamedTuple)
+    return length(x) == length(y) && Base.structdiff(x, y) === (;)
 end
 
 function _domain_label(t::TransformTuple, index::Int)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -316,6 +316,16 @@ end
     @test x ≈ x′
 end
 
+@testset "different order and superset of NamedTuple" begin
+    # test for #100
+    t = as((a = asℝ, b = asℝ))
+    @test @inferred(inverse(t, (a = 1.0, b = 2.0))) == [1.0, 2.0]
+    @test @inferred(inverse(t, (b = 2.0, a = 1.0))) == [1.0, 2.0]
+    @test_throws ArgumentError inverse(t, (; a = 1.0))
+    @test_throws ArgumentError inverse(t, (a = 1.0, b = 2.0, c = 3.0))
+    @test_throws ArgumentError inverse(t, (a = 1.0, c = 2.0))
+end
+
 ####
 #### log density correctness checks
 ####


### PR DESCRIPTION
I came across the problem described in #100, and for my use case (users provide named tuples that are `inverse`-transformed with a pre-defined transform) it would be convenient to support different orderings of NamedTuples in TransformTuple{<:NamedTuple}. Of course, one can argue that a NamedTuple with a different order of names is not in the image of the transform (as every `transform`ed result is a NamedTuple of a different order), but I think in practice in most applications `NamedTuple`s with differently ordered names are expected to behave in the same way and in the context of the transform one could justify this by operating with equivalence classes of named tuples with the same set of names.

So in this PR I propose to allow for differently ordered NamedTuples in the NamedTuple transform. However, if the NamedTuple is a superset still an error is thrown. This felt consistent with the dimension/size checks for array transforms.