### PR TITLE
Make `CallableTransform` and `CallableInverse` aliases of `Base.Fix1`

### DIFF
--- a/ext/ChangesOfVariablesExt.jl
+++ b/ext/ChangesOfVariablesExt.jl
@@ -4,10 +4,10 @@ import TransformVariables
 import ChangesOfVariables
 
 function ChangesOfVariables.with_logabsdet_jacobian(f::TransformVariables.CallableTransform, x)
-    return TransformVariables.transform_and_logjac(f.t, x)
+    return TransformVariables.transform_and_logjac(f.x, x)
 end
 function ChangesOfVariables.with_logabsdet_jacobian(f::TransformVariables.CallableInverse, x)
-    return TransformVariables.inverse_and_logjac(f.t, x)
+    return TransformVariables.inverse_and_logjac(f.x, x)
 end
 
 end # module

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -125,6 +125,8 @@ transform(t, x) == transform(t)(x)
 """
 function transform end
 
+transform(t::AbstractTransform) = Base.Fix1(transform, t)
+
 """
 $(TYPEDEF)
 
@@ -137,9 +139,25 @@ function Base.show(io::IO, f::CallableTransform)
     print(io, "callable for the transformation ", f.x)
 end
 
-transform(t) = Base.Fix1(transform, t)
+inverse(f::CallableTransform) = Base.Fix1(inverse, f.x)
+InverseFunctions.inverse(f::CallableTransform) = inverse(f)
 
 ChangesOfVariables.with_logabsdet_jacobian(f::CallableTransform, x) = transform_and_logjac(f.x, x)
+
+"""
+`$(FUNCTIONNAME)(t, y)`
+
+Return `x` so that `transform(t, x) ≈ y`.
+
+`$(FUNCTIONNAME)(t)`
+
+Return a callable equivalent to `y -> inverse(t, y)`. `t` can also be a callable created
+with transform, so the following holds:
+```julia
+inverse(t)(y) == inverse(t, y) == inverse(transform(t))(y)
+```
+"""
+inverse(t::AbstractTransform) = Base.Fix1(inverse, t)
 
 """
 $(TYPEDEF)
@@ -156,27 +174,7 @@ end
 inverse(f::CallableInverse) = Base.Fix1(transform, f.x)
 InverseFunctions.inverse(f::CallableInverse) = inverse(f)
 
-inverse(f::CallableTransform) = Base.Fix1(inverse, f.x)
-InverseFunctions.inverse(f::CallableTransform) = inverse(f)
-
 ChangesOfVariables.with_logabsdet_jacobian(f::CallableInverse, x) = inverse_and_logjac(f.x, x)
-
-"""
-`$(FUNCTIONNAME)(t, y)`
-
-Return `x` so that `transform(t, x) ≈ y`.
-
-`$(FUNCTIONNAME)(t)`
-
-Return a callable equivalent to `y -> inverse(t, y)`. `t` can also be a callable created
-with transform, so the following holds:
-```julia
-inverse(t)(y) == inverse(t, y) == inverse(transform(t))(y)
-```
-"""
-inverse(t::AbstractTransform) = CallableInverse(t)
-
-(f::CallableInverse)(y) = inverse(f.t, y)
 
 """
 `$(FUNCTIONNAME)(t::AbstractTransform, y)`

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -131,19 +131,15 @@ $(TYPEDEF)
 Partial application of `transform(t, x)`, callable with `x`. Use `transform(t)` to
 construct.
 """
-struct CallableTransform{T}
-    t::T
-end
-
-(f::CallableTransform)(x) = transform(f.t, x)
+const CallableTransform{T} = Base.Fix1{typeof(transform),T<:AbstractTransform}
 
 function Base.show(io::IO, f::CallableTransform)
-    print(io, "callable for the transformation $(f.t)")
+    print(io, "callable for the transformation ", f.x)
 end
 
-transform(t) = CallableTransform(t)
+transform(t) = Base.Fix1(transform, t)
 
-ChangesOfVariables.with_logabsdet_jacobian(f::CallableTransform, x) = transform_and_logjac(f.t, x)
+ChangesOfVariables.with_logabsdet_jacobian(f::CallableTransform, x) = transform_and_logjac(f.x, x)
 
 """
 $(TYPEDEF)
@@ -151,21 +147,19 @@ $(TYPEDEF)
 Partial application of `inverse(t, y)`, callable with `y`. Use `inverse(t)` to
 construct.
 """
-struct CallableInverse{T}
-    t::T
-end
+const CallableInverse{T} = Base.Fix1{typeof(inverse),T<:AbstractTransform}
 
 function Base.show(io::IO, f::CallableInverse)
-    print(io, "callable inverse for the transformation $(f.t)")
+    print(io, "callable inverse for the transformation ", f.x)
 end
 
-inverse(f::CallableInverse) = CallableTransform(f.t)
-InverseFunctions.inverse(f::CallableInverse) = CallableTransform(f.t)
+inverse(f::CallableInverse) = Base.Fix1(transform, f.x)
+InverseFunctions.inverse(f::CallableInverse) = inverse(f)
 
-inverse(f::CallableTransform) = CallableInverse(f.t)
-InverseFunctions.inverse(f::CallableTransform) = CallableInverse(f.t)
+inverse(f::CallableTransform) = Base.Fix1(inverse, f.x)
+InverseFunctions.inverse(f::CallableTransform) = inverse(f)
 
-ChangesOfVariables.with_logabsdet_jacobian(f::CallableInverse, x) = inverse_and_logjac(f.t, x)
+ChangesOfVariables.with_logabsdet_jacobian(f::CallableInverse, x) = inverse_and_logjac(f.x, x)
 
 """
 `$(FUNCTIONNAME)(t, y)`

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -131,7 +131,7 @@ $(TYPEDEF)
 Partial application of `transform(t, x)`, callable with `x`. Use `transform(t)` to
 construct.
 """
-const CallableTransform{T} = Base.Fix1{typeof(transform),T<:AbstractTransform}
+const CallableTransform{T} = Base.Fix1{typeof(transform),T} where {T<:AbstractTransform}
 
 function Base.show(io::IO, f::CallableTransform)
     print(io, "callable for the transformation ", f.x)
@@ -147,7 +147,7 @@ $(TYPEDEF)
 Partial application of `inverse(t, y)`, callable with `y`. Use `inverse(t)` to
 construct.
 """
-const CallableInverse{T} = Base.Fix1{typeof(inverse),T<:AbstractTransform}
+const CallableInverse{T} = Base.Fix1{typeof(inverse),T} where {T<:AbstractTransform}
 
 function Base.show(io::IO, f::CallableInverse)
     print(io, "callable inverse for the transformation ", f.x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -583,8 +583,8 @@ end
 
 @testset "ChangesOfVariables" begin
     t = as(Real, 1.0, 3.0)
-    f = TransformVariables.CallableTransform(t)
-    inv_f = TransformVariables.CallableInverse(t)
+    f = transform(t)
+    inv_f = inverse(t)
     ChangesOfVariables.test_with_logabsdet_jacobian(f, -4.2, ForwardDiff.derivative)
     ChangesOfVariables.test_with_logabsdet_jacobian(inv_f, 1.7, ForwardDiff.derivative)
 end
@@ -592,8 +592,8 @@ end
 
 @testset "InverseFunctions" begin
     t = as(Real, 1.0, 3.0)
-    f = TransformVariables.CallableTransform(t)
-    inv_f = TransformVariables.CallableInverse(t)
+    f = transform(t)
+    inv_f = inverse(t)
     InverseFunctions.test_inverse(f, -4.2)
     InverseFunctions.test_inverse(inv_f, 1.7)
 end


### PR DESCRIPTION
I assume `CallableTransform` and `CallableInverse` predate the use of `Base.Fix1` etc. in the ecosystem. I think one could unify both paths of construction, `transform(t)` and `Base.Fix1(transform, t)` etc., and just make `CallableTransform` and `CallableInverse` special aliases of `Base.Fix1`.

Alternatively, one could remove these names completely, given that users have already been instructed to use `transform(t)` and `inverse(t)`.