### PR TITLE
Move support of InverseFunctions and ChangesOfVariables to extensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,14 +5,20 @@ version = "0.8.12"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
-ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[weakdeps]
+ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
+[extensions]
+ChangesOfVariablesExt = "ChangesOfVariables"
+InverseFunctionsExt = "InverseFunctions"
 
 [compat]
 ArgCheck = "1, 2"

--- a/ext/ChangesOfVariablesExt.jl
+++ b/ext/ChangesOfVariablesExt.jl
@@ -1,0 +1,13 @@
+module ChangesOfVariablesExt
+
+import TransformVariables
+import ChangesOfVariables
+
+function ChangesOfVariables.with_logabsdet_jacobian(f::TransformVariables.CallableTransform, x)
+    return TransformVariables.transform_and_logjac(f.t, x)
+end
+function ChangesOfVariables.with_logabsdet_jacobian(f::TransformVariables.CallableInverse, x)
+    return TransformVariables.inverse_and_logjac(f.t, x)
+end
+
+end # module

--- a/ext/InverseFunctionsExt.jl
+++ b/ext/InverseFunctionsExt.jl
@@ -1,0 +1,13 @@
+module InverseFunctionsExt
+
+import TransformVariables
+import InverseFunctions
+
+function InverseFunctions.inverse(f::TransformVariables.CallableTransform)
+    return TransformVariables.inverse(f)
+end
+function InverseFunctions.inverse(f::TransformVariables.CallableInverse)
+    return TransformVariables.inverse(f)
+end
+
+end # module

--- a/src/TransformVariables.jl
+++ b/src/TransformVariables.jl
@@ -8,9 +8,6 @@ using LinearAlgebra: UpperTriangular, logabsdet
 using Random: AbstractRNG, GLOBAL_RNG
 using StaticArrays: MMatrix, SMatrix, SArray, SVector, pushfirst
 
-import ChangesOfVariables
-import InverseFunctions
-
 include("utilities.jl")
 include("generic.jl")
 include("scalar.jl")

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -143,8 +143,6 @@ end
 
 transform(t) = CallableTransform(t)
 
-ChangesOfVariables.with_logabsdet_jacobian(f::CallableTransform, x) = transform_and_logjac(f.t, x)
-
 """
 $(TYPEDEF)
 
@@ -160,12 +158,8 @@ function Base.show(io::IO, f::CallableInverse)
 end
 
 inverse(f::CallableInverse) = CallableTransform(f.t)
-InverseFunctions.inverse(f::CallableInverse) = CallableTransform(f.t)
 
 inverse(f::CallableTransform) = CallableInverse(f.t)
-InverseFunctions.inverse(f::CallableTransform) = CallableInverse(f.t)
-
-ChangesOfVariables.with_logabsdet_jacobian(f::CallableInverse, x) = inverse_and_logjac(f.t, x)
 
 """
 `$(FUNCTIONNAME)(t, y)`


### PR DESCRIPTION
This PR downgrade InverseFunctions and ChangesOfVariables to weak dependencies. This should be non-breaking since their functions haven't been exported anyway, so users and downstream packages always had to load these packages explicitly anyway when calling them.