### PR TITLE
Make `inverse(::VectorTransfrom, x)` return a vector of floats

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TransformVariables"
 uuid = "84d833dd-6860-57f9-a1a7-6da5db126cff"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.8.15"
+version = "0.8.16"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -266,8 +266,17 @@ function transform_and_logjac(t::VectorTransform, x::AbstractVector)
     y, ℓ
 end
 
+# We want to avoid vectors with non-numerical element types
+# Ref https://github.com/tpapp/TransformVariables.jl/issues/132
 function inverse(t::VectorTransform, y)
-    inverse!(Vector{inverse_eltype(t, y)}(undef, dimension(t)), t, y)
+    inverse!(Vector{_float_or_Float64(inverse_eltype(t, y))}(undef, dimension(t)), t, y)
+end
+function _float_or_Float64(::Type{T}) where T
+    if T !== Union{} && T <: Number # heuristic: it is assumed that every `Number` type defines `float`
+        return float(T)
+    else
+        return Float64
+    end
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -730,3 +730,33 @@ end
     end
     @test d1 == d2
 end
+
+@testset "inverse of VectorTransform" begin
+    # `VectorTransform` with empty `inverse`
+    for a in (3, 4.7, [5])
+        x = @inferred(inverse(as((; a = Constant(a))), (; a)))
+        @test x isa Vector{Float64}
+        @test isempty(x)
+
+        x = @inferred(inverse(as((Constant(a),)), (a,)))
+        @test x isa Vector{Float64}
+        @test isempty(x)
+
+        x = @inferred(inverse(as(Vector, Constant(a), 1), [a]))
+        @test x isa Vector{Float64}
+        @test isempty(x)
+    end
+
+    # `VectorTransform` with integer input
+    x = @inferred(inverse(as((; a = asℝ)), (; a = 3)))
+    @test x isa Vector{Float64}
+    @test x == [3]
+
+    x = @inferred(inverse(as((asℝ,)), (3,)))
+    @test x isa Vector{Float64}
+    @test x == [3]
+
+    x = @inferred(inverse(as(Vector, asℝ, 1), [3]))
+    @test x isa Vector{Float64}
+    @test x == [3]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -732,8 +732,8 @@ end
 end
 
 @testset "inverse of VectorTransform" begin
-    # `VectorTransform` with empty `inverse`
-    for a in (3, 4.7, [5])
+    # Empty `inverse(::VectorTransform, _)`
+    for a in (3, 4.7, [5], 3f0, 4.7f0, [5f0])
         x = @inferred(inverse(as((; a = Constant(a))), (; a)))
         @test x isa Vector{Float64}
         @test isempty(x)
@@ -747,16 +747,20 @@ end
         @test isempty(x)
     end
 
-    # `VectorTransform` with integer input
-    x = @inferred(inverse(as((; a = asℝ)), (; a = 3)))
-    @test x isa Vector{Float64}
-    @test x == [3]
+    # Element type of `inverse(::VectorTransform, _)`
+    for a in (3, 3.0, 3f0)
+        T = float(typeof(a))
 
-    x = @inferred(inverse(as((asℝ,)), (3,)))
-    @test x isa Vector{Float64}
-    @test x == [3]
+        x = @inferred(inverse(as((; a = asℝ)), (; a)))
+        @test x isa Vector{T}
+        @test x == [3]
 
-    x = @inferred(inverse(as(Vector, asℝ, 1), [3]))
-    @test x isa Vector{Float64}
-    @test x == [3]
+        x = @inferred(inverse(as((asℝ,)), (a,)))
+        @test x isa Vector{T}
+        @test x == [3]
+
+        x = @inferred(inverse(as(Vector, asℝ, 1), [a]))
+        @test x isa Vector{T}
+        @test x == [3]
+    end
 end


### PR DESCRIPTION
Fixes #132.

I was debating with myself whether this should be addressed in `inverse` or `inverse_eltype`. I came to the conclusion that `inverse` is the right place because modifications in `inverse_eltype` could lead to undesired results (too early change to floats or `Float64`) when composing vector transforms (and the current `inverse_eltype` definitions are not actually incorrect).