### PR TITLE
Change UnitVector transform to use normalization

### DIFF
--- a/src/TransformVariables.jl
+++ b/src/TransformVariables.jl
@@ -4,7 +4,7 @@ using ArgCheck: @argcheck
 using DocStringExtensions: FUNCTIONNAME, SIGNATURES, TYPEDEF
 import ForwardDiff
 using LogExpFunctions
-using LinearAlgebra: UpperTriangular, logabsdet
+using LinearAlgebra: UpperTriangular, logabsdet, norm, rmul!
 using Random: AbstractRNG, GLOBAL_RNG
 using StaticArrays: MMatrix, SMatrix, SArray, SVector, pushfirst
 using CompositionsBase

--- a/src/special_arrays.jl
+++ b/src/special_arrays.jl
@@ -73,7 +73,7 @@ struct UnitVector <: VectorTransform
     end
 end
 
-dimension(t::UnitVector) = t.n - 1
+dimension(t::UnitVector) = t.n
 
 function _summary_rows(transformation::UnitVector, mime)
     _summary_row(transformation, "$(transformation.n) element unit vector transformation")

--- a/src/special_arrays.jl
+++ b/src/special_arrays.jl
@@ -88,9 +88,8 @@ function transform_with(flag::LogJacFlag, t::UnitVector, x::AbstractVector, inde
     (; n) = t
     T = robust_eltype(x)
     y = Vector{T}(undef, n)
-    z = view(x, index:index+n-1)
-    r = norm(z)
-    copyto!(y, z)
+    copyto!(y, 1, x, index, n)
+    r = norm(y)
     __normalize!(y, r)
     ℓ = flag isa NoLogJac ? flag : -r^2 / 2
     index += n
@@ -119,8 +118,7 @@ inverse_eltype(t::UnitVector, y::AbstractVector) = robust_eltype(y)
 function inverse_at!(x::AbstractVector, index, t::UnitVector, y::AbstractVector)
     (; n) = t
     @argcheck length(y) == n
-    z = view(x, index:index+n-1)
-    copyto!(z, y)
+    copyto!(x, index, y)
     index += n
     return index
 end

--- a/src/special_arrays.jl
+++ b/src/special_arrays.jl
@@ -68,7 +68,7 @@ Euclidean norm.
 struct UnitVector <: VectorTransform
     n::Int
     function UnitVector(n::Int)
-        @argcheck n ≥ 1 "Dimension should be positive."
+        @argcheck n ≥ 2 "Dimension should be at least 2."
         new(n)
     end
 end

--- a/src/special_arrays.jl
+++ b/src/special_arrays.jl
@@ -114,12 +114,10 @@ inverse_eltype(t::UnitVector, y::AbstractVector) = robust_eltype(y)
 function inverse_at!(x::AbstractVector, index, t::UnitVector, y::AbstractVector)
     (; n) = t
     @argcheck length(y) == n
-    log_r = zero(eltype(y))
-    @inbounds for yi in axes(y, 1)[1:(end-1)]
-        x[index], log_r = l2_remainder_inverse(y[yi], log_r)
-        index += 1
-    end
-    index
+    z = view(x, index:index+n-1)
+    copyto!(z, y)
+    index += n
+    return index
 end
 
 

--- a/src/special_arrays.jl
+++ b/src/special_arrays.jl
@@ -62,8 +62,13 @@ end
 """
     UnitVector(n)
 
-Transform `n-1` real numbers to a unit vector of length `n`, under the
+Transform `n` real numbers to a unit vector of length `n`, under the
 Euclidean norm.
+
+!!! note
+    This transform is non-bijective and is undefined at the origin.
+    If maximizing a target distribution whose density is constant for the unit vector,
+    then the maximizer is at the origin, and behavior is undefined.
 """
 struct UnitVector <: VectorTransform
     n::Int

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -529,7 +529,7 @@ end
         -(abs2(μ) + abs2(σ) + abs2(β) + α + δ[1] + δ[2])
     end
     P = TransformedLogDensities.TransformedLogDensity(t, f)
-    x = zeros(dimension(t))
+    x = randn(dimension(t))
     v = logdensity(P, x)
     g = ForwardDiff.gradient(x -> logdensity(P, x), x)
 
@@ -642,7 +642,7 @@ end
 
     t = UnitVector(3)
     d = dimension(t)
-    x = [zeros(d), zeros(d)]
+    x = [randn(d), randn(d)]
     @test transform.(t, x) == map(x -> transform(t, x), x)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -378,7 +378,8 @@ end
     x = randn(dimension(tn))
     y = @inferred transform(tn, x)
     @test y isa NamedTuple{(:a,:b,:c)}
-    @test inverse(tn, y) ≈ x
+    x′ = inverse(tn, y)
+    @test inverse(tn, transform(tn, x′)) ≈ x′
     index = 0
     ljacc = 0.0
     for (i, t) in enumerate((t1, t2, t3))
@@ -416,11 +417,13 @@ end
     for _ in 1:10
         N = rand(3:7)
         tt = as((a = as(Tuple(as(Vector, asℝ₊, 2) for _ in 1:N)),
-                 b = as(Tuple(UnitVector(n) for n in 1:N))))
+                 b = as(Tuple(UnitVector(n) for n in 2:N))))
         x = randn(dimension(tt))
         y = transform(tt, x)
         x′ = inverse(tt, y)
-        @test x ≈ x′
+        m = sum(2:N)
+        @test x[1:end-m] ≈ x′[1:end-m]
+        @test inverse(tt, transform(tt, x′)) ≈ x′
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -756,7 +756,7 @@ end
     [98:98] 1 → asℝ
     [108:110] 2 → SMatrix{3,3} correlation cholesky factor
     [120:121] 3 → 3 element unit simplex transformation
-    [131:133] 4 → 4 element unit vector transformation"""
+    [131:134] 4 → 4 element unit vector transformation"""
     repr(MIME("text/plain"), t) == repr_t
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -194,7 +194,9 @@ end
 
 @testset "to unit vector" begin
     @testset "dimension checks" begin
-        U = UnitVector(3)
+        @test_throws ArgumentError UnitVector(0)
+        @test_throws ArgumentError UnitVector(1)
+        U = UnitVector(2)
         x = zeros(3)               # incorrect
         @test_throws ArgumentError transform(U, x)
         @test_throws ArgumentError transform_and_logjac(U, x)


### PR DESCRIPTION
This fixes #66 and relates #86

Length 1 unit vectors are no longer supported. While they are technically possible, they will likely suffer from numerical issues, since the transform is undefined at `x=0`, and for a Markov chain to travel from `y=[-1]` to `y[1]`, it would have to leap over the origin, which is only even possible due to discretization and likely will often not work.

Note the current implementation is bare-bones and has the limitation that it's not appropriate for optimization when the target distribution may include a unit-vector whose distribution is uniform on the sphere. I think it would be useful to accept a `logpr` function corresponding to `log(r^(1-n) p(r))` where `p(r)` is an (unnormalized) prior on the discarded norm `r`. As noted in https://github.com/tpapp/TransformVariables.jl/issues/86#issuecomment-1133638204 and https://discourse.mc-stan.org/t/a-better-unit-vector/26989/30, this would support providing an alternative prior in these rare cases whose `logpr` is not maximized at `r=0`. If this is welcome, I'll add it to the PR.