### PR TITLE
Introduce unit_vector_norm.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.8.17"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 CompositionsBase = "a33af91c-f02d-484b-be07-31d278c5ca2b"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -24,6 +25,7 @@ InverseFunctionsExt = "InverseFunctions"
 [compat]
 ArgCheck = "1, 2"
 ChangesOfVariables = "0.1"
+Compat = "4.10.0"
 CompositionsBase = "0.1.2"
 DocStringExtensions = "0.8, 0.9"
 ForwardDiff = "0.10, 1"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -146,6 +146,7 @@ produces positive quantities with the dimension of length.
 ## Special arrays
 
 ```@docs
+unit_vector_norm
 UnitVector
 UnitSimplex
 CorrCholeskyFactor

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -41,11 +41,15 @@ Further worked examples of using this package can be found in the [DynamicHMCExa
 
 # General interface
 
+## Transformations
+
 ```@docs
 dimension
 transform
 transform_and_logjac
 ```
+
+## Inverses
 
 ```@docs
 inverse
@@ -53,9 +57,15 @@ inverse!
 inverse_eltype
 ```
 
+## Integration into Bayesian inference
+
 ```@docs
 transform_logdensity
+TransformVariables.logprior
+TransformVariables.nonzero_logprior
 ```
+
+## Miscellaneous
 
 ```@docs
 domain_label

--- a/src/TransformVariables.jl
+++ b/src/TransformVariables.jl
@@ -1,6 +1,7 @@
 module TransformVariables
 
 using ArgCheck: @argcheck
+import Compat
 using DocStringExtensions: FUNCTIONNAME, SIGNATURES, TYPEDEF
 import ForwardDiff
 using LogExpFunctions

--- a/src/TransformVariables.jl
+++ b/src/TransformVariables.jl
@@ -4,7 +4,7 @@ using ArgCheck: @argcheck
 using DocStringExtensions: FUNCTIONNAME, SIGNATURES, TYPEDEF
 import ForwardDiff
 using LogExpFunctions
-using LinearAlgebra: UpperTriangular, logabsdet
+using LinearAlgebra: UpperTriangular, logabsdet, norm, rmul!
 using Random: AbstractRNG, GLOBAL_RNG
 using StaticArrays: MMatrix, SMatrix, SArray, SVector, pushfirst
 using CompositionsBase

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1,6 +1,8 @@
 export dimension, transform, transform_and_logjac, transform_logdensity, inverse, inverse!,
     inverse_eltype, as, domain_label
 
+public logprior, nonzero_logprior
+
 ###
 ### log absolute Jacobian determinant
 ###
@@ -109,6 +111,8 @@ The user interface consists of
 - [`transform_and_logjac`](@ref)
 - [`inverse`](@ref), [`inverse!`](@ref)
 - [`inverse_eltype`](@ref).
+- [`nonzero_logprior`](@ref).
+- [`logprior`](@ref)
 """
 abstract type AbstractTransform end
 
@@ -165,6 +169,30 @@ inverse(t)(y) == inverse(t, y) == inverse(transform(t))(y)
     concrete type even in corner cases.
 """
 inverse(t::AbstractTransform) = Base.Fix1(inverse, t)
+
+"""
+$(SIGNATURES)
+
+Return the log prior correction used in [`transform_and_logjac`](@ref). The second
+argument is the output of a transformation.
+
+The log jacobian determinant is corrected by this value, usually for the purpose of
+making a distribution proper. Can only be nonzero when [`nonzero_logprior`](@ref) is
+true.
+"""
+logprior(t::AbstractTransform, y) = 0.0
+
+"""
+$(SIGNATURES)
+
+Return `true` only if there are potential inputs for which [`logprior`](@ref) is
+nonzero.
+
+!!! note
+    Currently the only transformation that has a log prior correction is
+    [`unit_vector_norm`](@ref).
+"""
+nonzero_logprior(t::AbstractTransform) = false
 
 """
 $(TYPEDEF)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1,7 +1,7 @@
 export dimension, transform, transform_and_logjac, transform_logdensity, inverse, inverse!,
     inverse_eltype, as, domain_label
 
-public logprior, nonzero_logprior
+Compat.@compat public logprior, nonzero_logprior
 
 ###
 ### log absolute Jacobian determinant

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -180,7 +180,7 @@ The log jacobian determinant is corrected by this value, usually for the purpose
 making a distribution proper. Can only be nonzero when [`nonzero_logprior`](@ref) is
 true.
 """
-logprior(t::AbstractTransform, y) = 0.0
+logprior(t::AbstractTransform, y) = false # =0, to avoid unnecessary promotions
 
 """
 $(SIGNATURES)

--- a/src/special_arrays.jl
+++ b/src/special_arrays.jl
@@ -129,7 +129,7 @@ end
 $(SIGNATURES)
 
 Transform `n ≥ 2` real numbers to a unit vector of length `n` and a radius, under the
-Euclidean norm.
+Euclidean norm. Returns the tuple `(normalized_vector, radius)`.
 
 When `chi_prior = true`, a prior correction is applied to the radius, which only
 affects the log Jacobian determinant. The purpose of this is to make the

--- a/src/special_arrays.jl
+++ b/src/special_arrays.jl
@@ -68,7 +68,7 @@ Euclidean norm.
 struct UnitVector <: VectorTransform
     n::Int
     function UnitVector(n::Int)
-        Base.depwarn("UnitVector is deprecated. See `unit_vector_norm`.", UnitVector)
+        Base.depwarn("UnitVector is deprecated. See `unit_vector_norm`.", :UnitVector)
         @argcheck n ≥ 1 "Dimension should be positive."
         new(n)
     end

--- a/src/special_arrays.jl
+++ b/src/special_arrays.jl
@@ -152,7 +152,7 @@ unit_vector_norm(n::Int; chi_prior::Bool = true) = UnitVectorNorm(n; chi_prior)
 
 nonzero_logprior(t::UnitVectorNorm) = t.chi_prior
 
-function logprior(t::UnitVectorNorm, (y, r))
+function logprior(t::UnitVectorNorm, (y, r)::Tuple{AbstractVector,Real})
     (; n, chi_prior) = t
     if chi_prior
         (t.n - 1) * log(r) - r^2 / 2

--- a/src/special_arrays.jl
+++ b/src/special_arrays.jl
@@ -157,7 +157,7 @@ function logprior(t::UnitVectorNorm, (y, r)::Tuple{AbstractVector,Real})
     if chi_prior
         (t.n - 1) * log(r) - r^2 / 2
     else
-        zero(r)
+        float(zero(r))
     end
 end
 

--- a/src/special_arrays.jl
+++ b/src/special_arrays.jl
@@ -192,7 +192,7 @@ function inverse_at!(x::AbstractVector, index, t::UnitVectorNorm,
     @argcheck r ≥ 0
     _x = @view x[index:(index + n - 1)]
     if r == 0
-        _x .= zero(eltype(x))
+        fill!(_x, zero(eltype(x))
     else
         copyto!(_x, y)
         yN = norm(y, 2)

--- a/src/special_arrays.jl
+++ b/src/special_arrays.jl
@@ -192,7 +192,7 @@ function inverse_at!(x::AbstractVector, index, t::UnitVectorNorm,
     @argcheck r ≥ 0
     _x = @view x[index:(index + n - 1)]
     if r == 0
-        fill!(_x, zero(eltype(x))
+        fill!(_x, zero(eltype(x)))
     else
         copyto!(_x, y)
         yN = norm(y, 2)

--- a/src/special_arrays.jl
+++ b/src/special_arrays.jl
@@ -128,7 +128,7 @@ end
 """
 $(SIGNATURES)
 
-Transform `n` real numbers to a unit vector of length `n` and a radius, under the
+Transform `n ≥ 2` real numbers to a unit vector of length `n` and a radius, under the
 Euclidean norm.
 
 When `chi_prior = true`, a prior correction is applied to the radius, which only
@@ -140,6 +140,13 @@ manual correction, see also [`logprior`](@ref).
     At the origin, this transform is non-bijective and non-differentiable. If
     maximizing a target distribution whose density is constant for the unit vector,
     then the maximizer is at the origin, and behavior is undefined.
+
+!!! note
+    While ``n = 1`` would be technically possible, for practical purposes it would
+    likely suffer from numerical issues, since the transform is undefined at ``x = 0``,
+    and for a Markov chain to travel from ``y=[-1]`` to ``y=[1]``, it would have to leap
+    over the origin, which is only even possible due to discretization and likely will
+    often not work. Because of this, it is disallowed.
 """
 unit_vector_norm(n::Int; chi_prior::Bool = true) = UnitVectorNorm(n; chi_prior)
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -20,6 +20,24 @@ Number of elements (strictly) above the diagonal in an ``n×n`` matrix.
 """
 unit_triangular_dimension(n::Int) = n * (n-1) ÷ 2
 
+
+# Adapted from LinearAlgebra.__normalize!
+# MIT license
+# Copyright (c) 2018-2024 LinearAlgebra.jl contributors: https://github.com/JuliaLang/LinearAlgebra.jl/contributors
+@inline function __normalize!(a::AbstractArray, nrm)
+    # The largest positive floating point number whose inverse is less than infinity
+    δ = inv(prevfloat(typemax(nrm)))
+    if nrm ≥ δ # Safe to multiply with inverse
+        invnrm = inv(nrm)
+        rmul!(a, invnrm)
+    else # scale elements to avoid overflow
+        εδ = eps(one(nrm))/δ
+        rmul!(a, εδ)
+        rmul!(a, inv(nrm*εδ))
+    end
+    return a
+end
+
 ###
 ### type calculations
 ###

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -233,6 +233,7 @@ end
             test_transformation(t, _is_valid_yr; vec_y = _vec_yr)
 
             @test all(isnan, transform(t, zeros(dimension(t)))[1][1:(end-1)])
+            @test inverse(t, (zeros(K), 0.0)) == zeros(K)
 
             # no chi prior
             t = unit_vector_norm(K; chi_prior = false)
@@ -294,6 +295,12 @@ end
             end
         end
     end
+end
+
+@testset "logprior fallbacks" begin
+    struct DummyTransformation <: AbstractTransform end
+    @test !TransformVariables.nonzero_logprior(DummyTransformation())
+    @test TransformVariables.logprior(DummyTransformation(), 2.0) == 0.0
 end
 
 ####

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -14,6 +14,8 @@ function AD_logjac(t::VectorTransform, x, vec_y)
         # for generalized Jacobian determinant, see
         # - https://encyclopediaofmath.org/wiki/Jacobian#Generalizations_of_the_Jacobian_determinant
         # - https://en.wikipedia.org/wiki/Area_formula_(geometric_measure_theory)
+        # NOTE code below only works when the density is written wrt the Hausdorff measure.
+        # see https://github.com/tpapp/TransformVariables.jl/pull/139#discussion_r2071715166
         logabsdet(J' * J)[1] / 2
     end
 end


### PR DESCRIPTION
Co-authored-by: @sethaxen

- add unit_vector_transform using a projection to the unit sphere. fixes #66
- deprecates `UnitVector` (better to change the name for a new transformation), closing #86
- add a generic interface for log prior corrections (public, but not exported)