### PR TITLE
Make `inverse_and_logjac` for `TVExp` more efficient

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TransformVariables"
 uuid = "84d833dd-6860-57f9-a1a7-6da5db126cff"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.8.23"
+version = "0.8.24"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -74,7 +74,10 @@ function inverse(::TVExp, x::Number)
     log(x)
 end
 
-inverse_and_logjac(t::TVExp, x::Number) = inverse(t, x), -log(x)
+function inverse_and_logjac(t::TVExp, x::Number)
+    log_x = log(x)
+    return log_x, -log_x
+end
 
 """
 $(TYPEDEF)


### PR DESCRIPTION
Tiny efficiency improvement.

I had accidentally committed this to the master branch in the web editor (reverted it), but it might be a good idea to disallow pushes to the main branch.